### PR TITLE
UTF-8 -> Unicode code points

### DIFF
--- a/rte/CMakeLists.txt
+++ b/rte/CMakeLists.txt
@@ -35,10 +35,8 @@ SET(brux_gtk_sources
         shapes.cpp
         sprite.cpp
         text.cpp
-        tile.cpp
-        tinyxml2.cpp
-        tmap.cpp
-         Phyisics.cpp)
+        physics.cpp
+	actors.cpp)
 
 add_executable(brux-gdk ${brux_gtk_sources})
 if (NOT WIN32)

--- a/rte/actors.h
+++ b/rte/actors.h
@@ -1,0 +1,6 @@
+#ifndef _ACTORS_H_
+#define _ACTORS_H_
+
+void xyLoadActors();
+
+#endif

--- a/rte/binds.cpp
+++ b/rte/binds.cpp
@@ -999,6 +999,37 @@ SQInteger sqChint(HSQUIRRELVM v) {
 	return 1;
 }
 
+SQInteger sqStringLen(HSQUIRRELVM v) {
+  const char* s;
+  sq_getstring(v, 2, &s);
+
+  //convert to a string, only because it's easier to iterate through
+  std::string str = s;
+  int len = 0;
+
+  //to properly count the length of multi-byte characters, the same logic has to apply as in
+  //the draw function, where UTF-8 values have their most significant bits checked.
+  //this time it's a little easier though, as it's just a matter of iterating through the string
+  //and incrementing the counter appropriately
+  for(int i = 0; i < str.length(); i++){
+    //this process requires no shifting, so only each byte is needed
+    uint8_t c = str[i];
+
+    //if there are 3 bytes, then skip 2
+    if ((c & 0xE0) == 0xE0){
+      i += 2;
+      //if there are two bytes, then skip 1
+    }else if ((c & 0xC0) == 0xC0){
+      i += 1;
+    }
+
+    len += 1;
+  }
+
+  sq_pushinteger(v, len);
+  return 1;
+}
+
 //}
 
 ///////////

--- a/rte/binds.h
+++ b/rte/binds.h
@@ -108,6 +108,7 @@ SQInteger sqLenDirY(HSQUIRRELVM v);
 SQInteger sqNewFont(HSQUIRRELVM v);
 SQInteger sqDrawText(HSQUIRRELVM v);
 SQInteger sqChint(HSQUIRRELVM v);
+SQInteger sqStringLen(HSQUIRRELVM v);
 
 //Audio
 SQInteger sqLoadSound(HSQUIRRELVM v);

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -373,6 +373,7 @@ void xyBindAllFunctions(HSQUIRRELVM v) {
 	xyBindFunc(v, sqNewFont, "newFont", 6, ".nnnnn");
 	xyBindFunc(v, sqDrawText, "drawText", 5, ".nnns");
 	xyBindFunc(v, sqChint, "chint", 2, ".i");
+	xyBindFunc(v, sqStringLen, "stringLen", 2, ".s");
 
 	//File IO
 	xyPrint(0, "Embedding file I/O...");


### PR DESCRIPTION
Better solution for #27 

Rather than taking the approach of fiddling around with converters/wrappers with CP437, instead this code undoes the encoding of Unicode code points into UTF-8 using bit manipulation (https://en.wikipedia.org/wiki/UTF-8#Examples). Now, when a string is passed to the draw function, the Unicode code point of each character is extracted from the UTF-8 byte representation, and _that_ value instead is passed as the index into the bitmap.

Like before, a new bind is needed to handle multi-byte characters, as Squirrel's string length function will over-count those characters. This bind uses the same process as the draw function, but without the bit manipulation.

This worked on my end with the Unifont file in SuperTux, as that bitmap has each character drawn in order of Unicode code point, and I tested it using some Cyrillic script from the Bulgarian translation.

CP437 bitmaps will still work to the same extent as before, as ASCII values retain their index due to compatibility. If anything, it'd probably be easier to make them work fully as you could just map the code point to the proper index in that type of bitmap.

The only catch is that the code only supports up to U+FFFF, as I'm only checking for 3 significant bits in the bit operations. It wouldn't be difficult to add support for more planes, but this alone covers the entirety of Plane 0 in Unicode.