### PR TITLE
Add macOS compile instructions and correct include issues

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,8 @@ Download the [Squirrel library](https://squirrel-lang.org)  and compile using Ma
 
 If you're building for Windows, make sure you have SDL2 configured for MinGW, and use MinGW to build Squirrel, not standard GCC.
 
+If you're building for macOS, place the generated `.a` files into `/Library/Developer/CommandLineTools/usr/lib`. You will need administrator privileges for this. Place the `.h` files into `/Library/Developer/CommandLineTools/usr/include`. Again, you will also need administator privileges for this.
+
 Go to the `rte` folder and run `make` or `make linux`. The file `brux` should appear in `rte/bin`. To build for Windows, run `make windows`, which should produce `brux.exe` in `rte/bin`. For a MIPS Linux system, use `make gcw0`, provided you have the GCW-Zero toolchain configured. You will need to build Squirrel for that as well.
 
 ## Installing From Binary
@@ -27,3 +29,4 @@ Place `brux.exe` anywhere and associate `.brx` files with it.
 ### Mac
 
 You're on your own, buddy.
+azreigh-todo: add macOS instructions for installing from binary

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,12 +5,13 @@
 If you already have a binary package built, skip to the binary install section.
 
 Make sure you have all SDL2 development libraries installed, including image, gfx, mixer, and net. TTF is not used.
+You can obtain the SDL2 development libraries for macOS using [Brew](https://brew.sh/).
 
 Download the [Squirrel library](https://squirrel-lang.org)  and compile using Make. It should compile using just a basic GCC install. Place the generated `.a` files into `/usr/lib`. You may need to use `sudo` or a root account to do this. Place the `.h` files into `/usr/include/squirrel3`. Again, you may need to be root.
 
 If you're building for Windows, make sure you have SDL2 configured for MinGW, and use MinGW to build Squirrel, not standard GCC.
 
-If you're building for macOS, place the generated `.a` files into `/Library/Developer/CommandLineTools/usr/lib/squirrel3`. You will need administrator privileges for this. Place the `.h` files into `/Library/Developer/CommandLineTools/usr/include/squirrel3`. Again, you will also need administator privileges for this.
+If you're building for macOS, compile Squirrel using make then place the generated `.a` files into `/Library/Developer/CommandLineTools/usr/lib/squirrel3`. You will need administrator privileges for this. Afterwards, place the `.h` files into `/Library/Developer/CommandLineTools/usr/include/squirrel3`. Again, you will also need administator privileges for this.
 
 Go to the `rte` folder and run `make` or `make linux`. The file `brux` should appear in `rte/bin`. To build for Windows, run `make windows`, which should produce `brux.exe` in `rte/bin`. For a MIPS Linux system, use `make gcw0`, provided you have the GCW-Zero toolchain configured. You will need to build Squirrel for that as well.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ Download the [Squirrel library](https://squirrel-lang.org)  and compile using Ma
 
 If you're building for Windows, make sure you have SDL2 configured for MinGW, and use MinGW to build Squirrel, not standard GCC.
 
-If you're building for macOS, place the generated `.a` files into `/Library/Developer/CommandLineTools/usr/lib`. You will need administrator privileges for this. Place the `.h` files into `/Library/Developer/CommandLineTools/usr/include`. Again, you will also need administator privileges for this.
+If you're building for macOS, place the generated `.a` files into `/Library/Developer/CommandLineTools/usr/lib/squirrel3`. You will need administrator privileges for this. Place the `.h` files into `/Library/Developer/CommandLineTools/usr/include/squirrel3`. Again, you will also need administator privileges for this.
 
 Go to the `rte` folder and run `make` or `make linux`. The file `brux` should appear in `rte/bin`. To build for Windows, run `make windows`, which should produce `brux.exe` in `rte/bin`. For a MIPS Linux system, use `make gcw0`, provided you have the GCW-Zero toolchain configured. You will need to build Squirrel for that as well.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,5 +29,4 @@ Place `brux.exe` anywhere and associate `.brx` files with it.
 
 ### Mac
 
-You're on your own, buddy.
-azreigh-todo: add macOS instructions for installing from binary
+Place `brux` into `/Library/Developer/CommandLineTools/bin` or `/Library/Developer/CommandLineTools/usr/bin` so you can use Brux via the command line.

--- a/rte/cJSON.c
+++ b/rte/cJSON.c
@@ -23,8 +23,7 @@
 /* cJSON */
 /* JSON parser in C. */
 
-#include <string>
-#include <cstring>
+#include <string.h>
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/rte/physics.h
+++ b/rte/physics.h
@@ -5,7 +5,7 @@
 #ifndef BRUX_GDK_PHYISICS_H
 #define BRUX_GDK_PHYISICS_H
 #include <chipmunk.h>
-#include <std::vector>
+#include <vector>
 
 class Phyisics
 {
@@ -21,8 +21,8 @@ private:
 	cpVect gravity;
 	cpSpace *space;
 	cpFloat timeStep;
-	std::std::vector<cpBody*>  bodylist;
-	std::std::vector<cpShape*> shapelist;
+	std::vector<cpBody*>  bodylist;
+	std::vector<cpShape*> shapelist;
 };
 
 #endif //BRUX_GDK_PHYISICS_H


### PR DESCRIPTION
Changes:
- INSTALL.md now tells the user where to place `.h` and `.a` files for macOS.
- ~~cJSON.c now includes `string.h` instead of `string` and `cstring`~~ `// This was changed in the main branch so you can ignore this line`
- physics.h now includes `vector` instead of `std::vector` and uses `std::vector` instead of `std::std::vector`