### PR TITLE
Implement PhysicsFS support

### DIFF
--- a/docs/fileio.md
+++ b/docs/fileio.md
@@ -5,13 +5,26 @@
 
 &nbsp;
 
+* <a name="mount"></a>**`mount( string )`**
+
+  Mounts (adds to the search path) a folder or an archive, referenced by the path `string`.
+  Wrapper of [PHYSFS_mount()](https://icculus.org/physfs/docs/html/physfs_8h.html#a8eb320e9af03dcdb4c05bbff3ea604d4).
+
+* <a name="unmount"></a>**`unmount( string )`**
+
+  Unmounts (removes from the search path) a folder or an archive, referenced by the path `string`.
+  Wrapper of [PHYSFS_unmount()](https://icculus.org/physfs/docs/html/physfs_8h.html#aab0e2ba90aa918b2ee1ed7c40293b442).
+
+> **NOTE:**
+  This function requires the **real** path to the archive or directory that was mounted, not the path where it is mounted in the search path.
+
 * <a name="fileExists"></a>**`fileExists( name )`**
 
   Checks if a file exists. Returns bool.
 
 * <a name="fileWrite"></a>**`fileWrite( name, string )`**
 
-  Overwrites a file's contents with a string.
+  Overwrites a file's contents with a string and saves the result in the write path.
 
 * <a name="fileRead"></a>**`fileRead( name )`**
 
@@ -19,7 +32,12 @@
 
 * <a name="fileAppend"></a>**`fileAppend( name, string )`**
 
-  Adds a string to the end of a file.
+  Adds a string to the end of a file and saves the result in the write path.
+
+* <a name="fileDelete"></a>**`fileDelete( string )`**
+
+  Deletes a file or directory in the write path.
+  Wrapper of [PHYSFS_delete()](https://icculus.org/physfs/docs/html/physfs_8h.html#a27a939bce4c1132bacdfcb3d3cc29e37).
 
 * <a name="jsonRead"></a>**`jsonRead( string )`**
 
@@ -35,6 +53,25 @@
 
   Returns the current working directory as a string.
 
+* <a name="getPrefDir"></a>**`getPrefDir( string, string )`**
+
+  Gets the user-and-app specific path, where files can be written.
+  Wrapper of [PHYSFS_getPrefDir()](https://icculus.org/physfs/docs/html/physfs_8h.html#acd87392d234d070695303521bb8052a5).
+
+* <a name="getWriteDir"></a>**`getWriteDir()`**
+
+  Returns the path where file writing is allowed.
+  Wrapper of [PHYSFS_getWriteDir()](https://icculus.org/physfs/docs/html/physfs_8h.html#a6533ff91180a4c8abfe24d458f6b9915).
+
+* <a name="setWriteDir"></a>**`setWriteDir( string )`**
+
+  Sets the path where file writing should be allowed. Writing directories are automatically prepended to the search path, overriding any matching files.
+  Wrapper of [PHYSFS_setWriteDir()](https://icculus.org/physfs/docs/html/physfs_8h.html#a36c408d40b3a93c8f9fc02a16c02e430).
+
+> **NOTE:**
+  The intended usage of this function is by providing the result of `getPrefDir()` as a parameter. This usage allows setting a proper writing directory for the game.
+  By default, Brux uses the `brux` (or `brux/brux`) user-and-app specific directory for writing.
+
 * <a name="chdir"></a>**`chdir( string )`**
 
   Attempts to change the current working directory.
@@ -46,6 +83,11 @@
 * <a name="isdir"></a>**`isdir( string )`**
 
   Returns whether or not `string` is a directory.
+
+* <a name="createDir"></a>**`createDir( string )`**
+
+  Creates a new directory with the name `string` in the write path.
+  Wrapper of [PHYSFS_mkdir()](https://icculus.org/physfs/docs/html/physfs_8h.html#ae11fb98bf8c08a2e028f52ac9a728aa9).
 
 * <a name="dostr"></a>**`dostr( string )`**
 

--- a/docs/fileio.md
+++ b/docs/fileio.md
@@ -5,10 +5,14 @@
 
 &nbsp;
 
-* <a name="mount"></a>**`mount( string )`**
+* <a name="mount"></a>**`mount( string1, string2, bool )`**
 
-  Mounts (adds to the search path) a folder or an archive, referenced by the path `string`.
+  Mounts (adds to the search path) a folder or an archive, referenced by the path `string1`, to the mountpoint `string2`.
+  If `bool` is set to `true`, the files being mounted will be prepended on top of the search path, overriding any matching ones.
   Wrapper of [PHYSFS_mount()](https://icculus.org/physfs/docs/html/physfs_8h.html#a8eb320e9af03dcdb4c05bbff3ea604d4).
+
+> **NOTE:**
+  To mount to the root of the search path, provide `"/"` as the mountpoint.
 
 * <a name="unmount"></a>**`unmount( string )`**
 
@@ -65,7 +69,7 @@
 
 * <a name="setWriteDir"></a>**`setWriteDir( string )`**
 
-  Sets the path where file writing should be allowed. Writing directories are automatically prepended to the search path, overriding any matching files.
+  Sets the path where file writing should be allowed. Writing directories are automatically prepended to the root of the search path, overriding any matching files.
   Wrapper of [PHYSFS_setWriteDir()](https://icculus.org/physfs/docs/html/physfs_8h.html#a36c408d40b3a93c8f9fc02a16c02e430).
 
 > **NOTE:**

--- a/ide/syntax/brux.xml
+++ b/ide/syntax/brux.xml
@@ -134,6 +134,7 @@ Comes packaged with the BRUX IDE and works with anything that uses KTextEditor o
 			<item>drawSprite</item>
 			<item>drawText</item>
 			<item>fileAppend</item>
+			<item>fileDelete</item>
 			<item>fileExists</item>
 			<item>fileRead</item>
 			<item>fileWrite</item>

--- a/ide/syntax/brux.xml
+++ b/ide/syntax/brux.xml
@@ -116,6 +116,7 @@ Comes packaged with the BRUX IDE and works with anything that uses KTextEditor o
 			<item>choose</item>
 			<item>clearScreen</item>
 			<item>countActors</item>
+			<item>createDir</item>
 			<item>deleteActor</item>
 			<item>deleteMusic</item>
 			<item>deleteSound</item>
@@ -143,9 +144,11 @@ Comes packaged with the BRUX IDE and works with anything that uses KTextEditor o
 			<item>getFrames</item>
 			<item>getMusicVolume</item>
 			<item>getOS</item>
+			<item>getPrefDir</item>
 			<item>getQuit</item>
 			<item>getSoundVolume</item>
 			<item>getTicks</item>
+			<item>getWriteDir</item>
 			<item>getdir</item>
 			<item>hitLineCircle</item>
 			<item>hitLineLine</item>
@@ -184,6 +187,7 @@ Comes packaged with the BRUX IDE and works with anything that uses KTextEditor o
 			<item>loadMusic</item>
 			<item>loadSound</item>
 			<item>lsdir</item>
+			<item>mount</item>
 			<item>mouseDown</item>
 			<item>mousePress</item>
 			<item>mouseRelease</item>
@@ -222,6 +226,7 @@ Comes packaged with the BRUX IDE and works with anything that uses KTextEditor o
 			<item>setSoundVolume</item>
 			<item>setWindowIcon</item>
 			<item>setWindowTitle</item>
+			<item>setWriteDir</item>
 			<item>spriteH</item>
 			<item>spriteName</item>
 			<item>spriteSetBlendMode</item>
@@ -231,6 +236,7 @@ Comes packaged with the BRUX IDE and works with anything that uses KTextEditor o
 			<item>stopSound</item>
 			<item>textureSetBlendMode</item>
 			<item>toggleFullscreen</item>
+			<item>unmount</item>
 			<item>update</item>
 			<item>wait</item>
 			<item>windowH</item>

--- a/rte/binds.cpp
+++ b/rte/binds.cpp
@@ -299,6 +299,44 @@ SQInteger sqFileExists(HSQUIRRELVM v) {
 	return 1;
 };
 
+SQInteger sqFileDelete(HSQUIRRELVM v) {
+	const char* file;
+
+	sq_getstring(v, 2, &file);
+
+	xyFileDelete(file);
+
+	return 0;
+};
+
+SQInteger sqIsDir(HSQUIRRELVM v) {
+	const char* dir;
+
+	sq_getstring(v, 2, &dir);
+
+	sq_pushbool(v, xyIsDirectory(dir));
+
+	return 1;
+};
+
+SQInteger sqLsDir(HSQUIRRELVM v) {
+	const char* dir;
+
+	sq_getstring(v, 2, &dir);
+
+	// Create array for results.
+	sq_newarray(v, 0);
+
+	// Append all results to the array.
+	const std::vector<std::string> files = xyListDirectory(dir);
+	for (const std::string& file : files) {
+		sq_pushstring(v, file.c_str(), file.size());
+		sq_arrayappend(v, -2);
+	}
+
+	return 1;
+};
+
 
 
 //////////////

--- a/rte/binds.cpp
+++ b/rte/binds.cpp
@@ -177,6 +177,118 @@ SQInteger sqDoString(HSQUIRRELVM v) {
 	return 0;
 }
 
+SQInteger sqMount(HSQUIRRELVM v) {
+	const char* dir;
+	SQBool prepend;
+
+	sq_getstring(v, 2, &dir);
+	sq_getbool(v, 3, &prepend);
+
+	xyFSMount(dir, prepend);
+
+	return 0;
+};
+
+SQInteger sqUnmount(HSQUIRRELVM v) {
+	const char* dir;
+
+	sq_getstring(v, 2, &dir);
+
+	xyFSUnmount(dir);
+
+	return 0;
+};
+
+SQInteger sqGetDir(HSQUIRRELVM v) {
+	const std::string data = xyGetDir();
+
+	sq_pushstring(v, data.c_str(), data.size());
+
+	return 1;
+};
+
+SQInteger sqGetWriteDir(HSQUIRRELVM v) {
+	const std::string data = xyGetWriteDir();
+
+	sq_pushstring(v, data.c_str(), data.size());
+
+	return 1;
+};
+
+SQInteger sqGetPrefDir(HSQUIRRELVM v) {
+	const char* org;
+	const char* app;
+
+	sq_getstring(v, 2, &org);
+	sq_getstring(v, 3, &app);
+
+	const std::string data = xyGetPrefDir(org, app);
+
+	sq_pushstring(v, data.c_str(), data.size());
+
+	return 1;
+};
+
+SQInteger sqSetWriteDir(HSQUIRRELVM v) {
+	const char* dir;
+
+	sq_getstring(v, 2, &dir);
+
+	xySetWriteDir(dir);
+
+	return 0;
+};
+
+SQInteger sqCreateDir(HSQUIRRELVM v) {
+	const char* name;
+
+	sq_getstring(v, 2, &name);
+
+	xyCreateDir(name);
+
+	return 0;
+};
+
+SQInteger sqFileRead(HSQUIRRELVM v) {
+	const char* file;
+
+	sq_getstring(v, 2, &file);
+
+	if (xyFileExists(file)) {
+		const std::string data = xyFileRead(file);
+		sq_pushstring(v, data.c_str(), data.size());
+	}
+	else {
+		xyPrint(0, "WARNING: %s does not exist!", file);
+		sq_pushstring(v, "-1", 2);
+	}
+	return 1;
+};
+
+SQInteger sqFileWrite(HSQUIRRELVM v) {
+	const char* file;
+	const char* data;
+
+	sq_getstring(v, 2, &file);
+	sq_getstring(v, 3, &data);
+
+	xyFileWrite(file, data);
+
+	return 0;
+};
+
+SQInteger sqFileAppend(HSQUIRRELVM v) {
+	const char* file;
+	const char* data;
+
+	sq_getstring(v, 2, &file);
+	sq_getstring(v, 3, &data);
+
+	xyFileAppend(file, data);
+
+	return 0;
+};
+
 SQInteger sqFileExists(HSQUIRRELVM v) {
 	const char* file;
 
@@ -185,73 +297,6 @@ SQInteger sqFileExists(HSQUIRRELVM v) {
 	sq_pushbool(v, xyFileExists(file));
 
 	return 1;
-};
-
-SQInteger sqGetDir(HSQUIRRELVM v) {
-	char* buff = getCD(NULL, 0);
-	sq_pushstring(v, buff, strlen(buff));
-	return 1;
-};
-
-SQInteger sqSetDir(HSQUIRRELVM v) {
-	const char* d;
-	sq_getstring(v, 2, &d);
-	chdir(d);
-	return 0;
-};
-
-SQInteger sqFileWrite(HSQUIRRELVM v) {
-	const char* f;
-	const char* s;
-
-	sq_getstring(v, 2, &f);
-	sq_getstring(v, 3, &s);
-
-	std::ofstream fi;
-	fi.open(f, ios::out);
-	fi << s;
-	fi.close();
-
-	return 0;
-};
-
-SQInteger sqFileAppend(HSQUIRRELVM v) {
-	const char* f;
-	const char* s;
-
-	sq_getstring(v, 2, &f);
-	sq_getstring(v, 3, &s);
-
-	std::ofstream fi;
-	fi.open(f, ios::out | ios::app);
-	fi << s;
-	fi.close();
-
-	return 0;
-};
-
-SQInteger sqFileRead(HSQUIRRELVM v) {
-	const char* f;
-	int l;
-	std::ifstream t;
-
-	sq_getstring(v, 2, &f);
-
-	if(!xyFileExists(f)) {
-		xyPrint(0, "WARNING: %s does not exist!", f);
-		sq_pushstring(v, "-1", 2);
-		return 1;
-	} else {
-		t.open(f);
-		t.seekg(0, ios::end);
-		l = t.tellg();
-		char b[l];
-		t.seekg(0, ios::beg);
-		t.read(b, l);
-		t.close();
-		sq_pushstring(v, b, l);
-		return 1;
-	}
 };
 
 

--- a/rte/binds.cpp
+++ b/rte/binds.cpp
@@ -179,12 +179,14 @@ SQInteger sqDoString(HSQUIRRELVM v) {
 
 SQInteger sqMount(HSQUIRRELVM v) {
 	const char* dir;
+	const char* mountpoint;
 	SQBool prepend;
 
 	sq_getstring(v, 2, &dir);
-	sq_getbool(v, 3, &prepend);
+	sq_getstring(v, 3, &mountpoint);
+	sq_getbool(v, 4, &prepend);
 
-	xyFSMount(dir, prepend);
+	xyFSMount(dir, mountpoint, prepend);
 
 	return 0;
 };

--- a/rte/binds.h
+++ b/rte/binds.h
@@ -31,14 +31,17 @@ SQInteger sqToggleFullscreen(HSQUIRRELVM v);
 SQInteger sqImport(HSQUIRRELVM v);
 SQInteger sqDoNut(HSQUIRRELVM v);
 SQInteger sqDoString(HSQUIRRELVM v);
-SQInteger sqFileExists(HSQUIRRELVM v);
-SQInteger sqFileWrite(HSQUIRRELVM v);
-SQInteger sqFileRead(HSQUIRRELVM v);
-SQInteger sqFileAppend(HSQUIRRELVM v);
+SQInteger sqMount(HSQUIRRELVM v);
+SQInteger sqUnmount(HSQUIRRELVM v);
 SQInteger sqGetDir(HSQUIRRELVM v);
-SQInteger sqSetDir(HSQUIRRELVM v);
-SQInteger sqLsDir(HSQUIRRELVM v);
-SQInteger sqIsDir(HSQUIRRELVM v);
+SQInteger sqGetWriteDir(HSQUIRRELVM v);
+SQInteger sqGetPrefDir(HSQUIRRELVM v);
+SQInteger sqSetWriteDir(HSQUIRRELVM v);
+SQInteger sqCreateDir(HSQUIRRELVM v);
+SQInteger sqFileRead(HSQUIRRELVM v);
+SQInteger sqFileWrite(HSQUIRRELVM v);
+SQInteger sqFileAppend(HSQUIRRELVM v);
+SQInteger sqFileExists(HSQUIRRELVM v);
 
 //Graphics
 SQInteger sqWait(HSQUIRRELVM v);

--- a/rte/binds.h
+++ b/rte/binds.h
@@ -42,6 +42,9 @@ SQInteger sqFileRead(HSQUIRRELVM v);
 SQInteger sqFileWrite(HSQUIRRELVM v);
 SQInteger sqFileAppend(HSQUIRRELVM v);
 SQInteger sqFileExists(HSQUIRRELVM v);
+SQInteger sqFileDelete(HSQUIRRELVM v);
+SQInteger sqIsDir(HSQUIRRELVM v);
+SQInteger sqLsDir(HSQUIRRELVM v);
 
 //Graphics
 SQInteger sqWait(HSQUIRRELVM v);

--- a/rte/fileio.cpp
+++ b/rte/fileio.cpp
@@ -51,9 +51,9 @@ void xyFSDeinit() {
 
 /** General file system management functions. **/
 
-void xyFSMount(const std::string& dir, bool prepend) {
-	if (!PHYSFS_mount(dir.c_str(), NULL, !prepend))
-		throw PhysFSError("Cannot mount '" + dir + "'", "mount");
+void xyFSMount(const std::string& dir, const std::string& mountpoint, bool prepend) {
+	if (!PHYSFS_mount(dir.c_str(), mountpoint.c_str(), !prepend))
+		throw PhysFSError("Cannot mount '" + dir + "' to \"" + mountpoint + "\"", "mount");
 };
 
 void xyFSUnmount(const std::string& dir) {
@@ -101,9 +101,9 @@ void xySetWriteDir(const std::string& dir) {
 	if (!PHYSFS_setWriteDir(dir.c_str()))
 		throw PhysFSError("Error setting '" + dir + "' directory as write directory", "setWriteDir");
 
-	// Mount the write directory, so it prepends to (overrides) files in the search path.
+	// Mount and prepend the write directory to the root of the search path.
 	try {
-		xyFSMount(dir, true);
+		xyFSMount(dir, "/", true);
 	}
 	catch (const std::exception& err) {
 		std::stringstream out;

--- a/rte/fileio.cpp
+++ b/rte/fileio.cpp
@@ -1,20 +1,226 @@
+//  Brux - File I/O
+//  Copyright (C) 2016 KelvinShadewing
+//                2023 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 /*===============*\
 | FILE I/O SOURCE |
 \*===============*/
 
+#include <physfs.h>
 
+#include <filesystem>
 
 #include "main.h"
 #include "global.h"
 #include "fileio.h"
 
-bool xyFileExists(const char* file) {
-	//Checks if a file exists
-	struct stat buff;
-	if (stat(file, &buff) != -1) return true;
+/* Initalize a PhysicsFS error. */
+PhysFSError::PhysFSError(const std::string& message, const std::string& action) throw() :
+	m_message()
+{
+	const PHYSFS_ErrorCode code = PHYSFS_getLastErrorCode();
+	m_message = message + ": PHYSFS_" + action + " failed: " +
+							PHYSFS_getErrorByCode(code) + " (" + std::to_string(code) + ")";
+}
 
-	return false;
+/** File system initialization/destruction. **/
+
+void xyFSInit() {
+	if (!PHYSFS_init(NULL))
+		throw PhysFSError("Cannot initialize PhysicsFS", "init");
 };
+
+void xyFSDeinit() {
+	if (!PHYSFS_deinit())
+		throw PhysFSError("Cannot properly de-initialize PhysicsFS", "deinit");
+};
+
+
+/** General file system management functions. **/
+
+void xyFSMount(const std::string& dir, bool prepend) {
+	if (!PHYSFS_mount(dir.c_str(), NULL, !prepend))
+		throw PhysFSError("Cannot mount '" + dir + "'", "mount");
+};
+
+void xyFSUnmount(const std::string& dir) {
+	if (!PHYSFS_unmount(dir.c_str()))
+		throw PhysFSError("Cannot unmount '" + dir + "'", "unmount");
+};
+
+
+std::string xyGetDir() {
+	// Get the current working directory.
+	return getcwd(0, 0);
+}
+
+std::string xyGetWriteDir() {
+	const char* write_dir = PHYSFS_getWriteDir();
+	if (write_dir == NULL)
+		return "";
+	else
+		return write_dir;
+};
+
+std::string xyGetPrefDir(const std::string& org, const std::string& app) {
+	const char* dir = PHYSFS_getPrefDir(org.c_str(), app.c_str());
+	if (dir == NULL)
+		throw PhysFSError("Error getting user-and-app specific directory", "getPrefDir");
+
+	return dir;
+};
+
+void xySetWriteDir(const std::string& dir) {
+	// If there is a current write directory, unmount it.
+	const std::string write_dir = xyGetWriteDir();
+	if (!write_dir.empty())
+	{
+		try {
+			xyFSUnmount(write_dir);
+		}
+		catch (const std::exception& err) {
+			std::stringstream out;
+			out << "Error unmounting current write directory: " << err.what();
+			throw std::runtime_error(out.str());
+		}
+	}
+
+	if (!PHYSFS_setWriteDir(dir.c_str()))
+		throw PhysFSError("Error setting '" + dir + "' directory as write directory", "setWriteDir");
+
+	// Mount the write directory, so it prepends to (overrides) files in the search path.
+	try {
+		xyFSMount(dir, true);
+	}
+	catch (const std::exception& err) {
+		std::stringstream out;
+		out << "Error mounting write directory: " << err.what();
+		throw std::runtime_error(out.str());
+	}
+};
+
+
+void xyCreateDir(const std::string& name) {
+	if (!PHYSFS_mkdir(name.c_str()))
+		throw PhysFSError("Could not create directory '" + name + "'", "mkdir");
+}
+
+std::string xyFileRead(const std::string& file)
+{
+	// Check if the file exists.
+	if (!xyFileExists(file))
+		throw std::runtime_error("File '" + file + "' doesn't exist.");
+
+	PHYSFS_file* handle = PHYSFS_openRead(file.c_str());
+	const int length = PHYSFS_fileLength(handle);
+
+	char* buffer = new char[length + 1];
+	buffer[length] = 0; // Terminate string at the end.
+	if (PHYSFS_readBytes(handle, buffer, length) <= 0)
+		throw PhysFSError("Cannot read any data from file '" + file + "'", "readBytes");
+
+	// Copy the result and delete the pointer.
+	const std::string result = buffer;
+	delete[] buffer;
+
+	PHYSFS_close(handle);
+	return result;
+};
+
+void xyFileWrite(const std::string& file, const std::string& data)
+{
+	// If the full path to the file's directory isn't available, create it.
+	xyCreateDir(std::filesystem::path(file).parent_path().string());
+
+	PHYSFS_file* handle = PHYSFS_openWrite(file.c_str());
+	const int length = data.size();
+
+	const char* buffer = data.c_str();
+	if (PHYSFS_writeBytes(handle, buffer, length) < length)
+		throw PhysFSError("Cannot write all data to file '" + file + "'", "writeBytes");
+
+	PHYSFS_close(handle);
+};
+
+void xyFileAppend(const std::string& file, const std::string& data)
+{
+	// If the file currently exists, read its data.
+	std::string file_data;
+	if (xyFileExists(file))
+		file_data = xyFileRead(file);
+
+	// Write old and new data.
+	xyFileWrite(file, file_data + data);
+};
+
+bool xyFileExists(const std::string& file) {
+	return PHYSFS_exists(file.c_str());
+};
+
+bool xyLegacyFileExists(const std::string& file) {
+	// This function should not be exposed, because it searches beyond PhysicsFS's search path.
+	// Only used for checking if the initial Squirrel file exists.
+
+	struct stat buff;
+	return stat(file.c_str(), &buff) != -1;
+}
+
+
+SQInteger sqLsDir(HSQUIRRELVM v) {
+	const char* dir;
+
+	sq_getstring(v, 2, &dir);
+
+	// Create array for results.
+	sq_newarray(v, 0);
+
+	// Read files and append to array.
+	char **rc = PHYSFS_enumerateFiles(dir);
+	if (rc == NULL) {
+		std::stringstream err;
+		err << "Error enumerating files in directory '" << dir << "'";
+		throw PhysFSError(err.str(), "enumerateFiles");
+	}
+	char **i;
+
+	for (i = rc; *i != NULL; i++) {
+		sq_pushstring(v, *i, strlen(*i));
+		sq_arrayappend(v, -2);
+	}
+
+	PHYSFS_freeList(rc);
+	return 1;
+};
+
+SQInteger sqIsDir(HSQUIRRELVM v) {
+	const char* dir;
+
+	sq_getstring(v, 2, &dir);
+
+	// Get file/directory stats.
+	PHYSFS_Stat stat;
+	PHYSFS_stat(dir, &stat);
+
+	sq_pushbool(v, stat.filetype == PHYSFS_FILETYPE_DIRECTORY);
+
+	return 1;
+};
+
+
+/** JSON encoding/decoding. **/
 
 // Credit to Nova Storm for the JSON encoding and decoding functions
 
@@ -85,49 +291,3 @@ SQInteger sqDecodeJSON(HSQUIRRELVM v) {
 	cJSON_Delete(Root);
 	return 1;
 }
-
-SQInteger sqLsDir(HSQUIRRELVM v) {
-	const SQChar *dir;
-	sq_getstring(v, 2, &dir);
-
-	//Get the current directory
-	DIR *folder;
-	struct dirent *entry;
-	std::string s_entry;
-
-	folder = opendir(dir);
-	if(folder == NULL) {
-		xyPrint(0, "Failed to open directory: %s\n", dir);
-		sq_pushstring(v, "", 0);
-		return 1;
-	} else {
-		sq_newarray(v, 0);
-        entry = readdir(folder);
-        while(entry) {
-			s_entry = entry->d_name;
-			sq_pushstring(v, s_entry.c_str(), s_entry.length());
-			sq_arrayappend(v, -2);
-            entry = readdir(folder);
-        }
-	}
-
-	closedir(folder);
-	return 1;
-};
-
-SQInteger sqIsDir(HSQUIRRELVM v) {
-	const SQChar *dir;
-	sq_getstring(v, 2, &dir);
-	struct stat info;
-
-	if(stat(dir, &info) != 0) {
-		sq_pushbool(v, false);
-		return 1;
-	} else if(info.st_mode & S_IFDIR) {
-		sq_pushbool(v, true);
-		return 1;
-	} else {
-		sq_pushbool(v, false);
-		return 1;
-	}
-};

--- a/rte/fileio.h
+++ b/rte/fileio.h
@@ -42,7 +42,7 @@ void xyFSInit();
 void xyFSDeinit();
 
 /** General file system management functions. **/
-void xyFSMount(const std::string& dir, bool prepend);
+void xyFSMount(const std::string& dir, const std::string& mountpoint, bool prepend);
 void xyFSUnmount(const std::string& dir);
 
 std::string xyGetDir();

--- a/rte/fileio.h
+++ b/rte/fileio.h
@@ -56,9 +56,10 @@ void xyFileWrite(const std::string& file, const std::string& data);
 void xyFileAppend(const std::string& file, const std::string& data);
 bool xyFileExists(const std::string& file);
 bool xyLegacyFileExists(const std::string& file);
+void xyFileDelete(const std::string& name);
 
-SQInteger sqLsDir(HSQUIRRELVM v);
-SQInteger sqIsDir(HSQUIRRELVM v);
+bool xyIsDirectory(const std::string& name);
+std::vector<std::string> xyListDirectory(const std::string& dir);
 
 /** JSON encoding/decoding. **/
 void sqDecodeJSONTable(HSQUIRRELVM v, cJSON *Item);

--- a/rte/fileio.h
+++ b/rte/fileio.h
@@ -1,18 +1,67 @@
+//  Brux - File I/O
+//  Copyright (C) 2016 KelvinShadewing
+//                2023 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 /*===============*\
 | FILE I/O HEADER |
 \*===============*/
 
-
-
 #ifndef _FILEIO_H_
 #define _FILEIO_H_
 
-#include "main.h"
+#include <string>
+#include <vector>
 
-bool xyFileExists(const char* file);
-void sqDecodeJSONTable(HSQUIRRELVM v, cJSON *Item);
-SQInteger sqDecodeJSON(HSQUIRRELVM v);
+/* A class that takes the last PhysicsFS error and converts it to a readable message. */
+class PhysFSError final : public std::exception
+{
+private:
+	std::string m_message;
+
+public:
+	PhysFSError(const std::string& message, const std::string& action) throw();
+
+	const char* what() const throw() { return m_message.c_str(); }
+};
+
+/** File system initialization/destruction. **/
+void xyFSInit();
+void xyFSDeinit();
+
+/** General file system management functions. **/
+void xyFSMount(const std::string& dir, bool prepend);
+void xyFSUnmount(const std::string& dir);
+
+std::string xyGetDir();
+std::string xyGetWriteDir();
+std::string xyGetPrefDir(const std::string& org, const std::string& app);
+void xySetWriteDir(const std::string& dir);
+
+void xyCreateDir(const std::string& name);
+std::string xyFileRead(const std::string& file);
+void xyFileWrite(const std::string& file, const std::string& data);
+void xyFileAppend(const std::string& file, const std::string& data);
+bool xyFileExists(const std::string& file);
+bool xyLegacyFileExists(const std::string& file);
+
 SQInteger sqLsDir(HSQUIRRELVM v);
 SQInteger sqIsDir(HSQUIRRELVM v);
+
+/** JSON encoding/decoding. **/
+void sqDecodeJSONTable(HSQUIRRELVM v, cJSON *Item);
+SQInteger sqDecodeJSON(HSQUIRRELVM v);
 
 #endif

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -64,16 +64,15 @@ int main(int argc, char* argv[]) {
 				//If the input is a Squirrel file
 				if(curarg.substr(curarg.find_last_of('.')) == ".sq" || curarg.substr(curarg.find_last_of('.')) == ".nut" || curarg.substr(curarg.find_last_of('.')) == ".brx"){
 					//Check that the file really exists
-					if(xyFileExists(curarg.c_str())) {
+					if(xyLegacyFileExists(curarg)) {
 						//All checks pass, assign the file
 						char tmpstr[64];
-						xygapp = curarg.c_str();
+						xygapp = curarg;
 						size_t found = xygapp.find_last_of("/\\");
 						gvWorkDir = xygapp.substr(0, found);
 						chdir(gvWorkDir.c_str());
-						char* curdir = getcwd(0,0);
-						xyPrint(0, "Working directory: %s", curdir);
-						delete curdir;
+						const std::string curdir = xyGetDir();
+						xyPrint(0, "Working directory: %s", curdir.c_str());
 					}
 				}
 			}
@@ -85,11 +84,19 @@ int main(int argc, char* argv[]) {
 
 	SDL_ShowCursor(0);
 
+	//Mount the current working directory.
+	xyFSMount(xyGetDir(), true);
+
+	//Set the current write directory to a default for Brux.
+	//Can be changed later by the game.
+	xySetWriteDir(xyGetPrefDir("brux", "brux"));
+
 	//Run app
 	if(xygapp != "") {
 		xyPrint(0, "Running %s...", xygapp.c_str());
 		sqstd_dofile(gvSquirrel, xygapp.c_str(), 0, 1);
-	} else {
+	}
+	else {
 		if(xyFileExists("test.nut")) sqstd_dofile(gvSquirrel, "test.nut", 0, 1);
 		else if(xyFileExists("game.brx")) sqstd_dofile(gvSquirrel, "game.brx", 0, 1);
 	}
@@ -113,6 +120,10 @@ int xyInit() {
 	//Print opening message
 	xyPrint(0, "\n/========================\\\n| BRUX GAME RUNTIME LOG |\n\\========================/\n\n");
 	xyPrint(0, "Initializing program...\n\n");
+
+	//Initialize the file system (PhysFS)
+	xyPrint(0, "Initializing file system...");
+	xyFSInit();
 
 	//Initiate SDL
 	SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "0");
@@ -250,6 +261,10 @@ void xyEnd(){
 	Mix_Quit();
 	SDL_Quit();
 
+	//Destroy the file system (PhysFS)
+	xyPrint(0, "Closing file system...");
+	xyFSDeinit();
+
 	//Close log file
 	xyPrint(0, "System closed successfully!");
 	gvLog.close();
@@ -274,8 +289,8 @@ void xyBindFunc(HSQUIRRELVM v, SQFUNCTION func, const SQChar *key) {
 };
 
 void xyBindFunc(HSQUIRRELVM v, SQFUNCTION func, const SQChar *key, SQInteger nParams, const SQChar* sParams) {
-  //Binds a function from C++ to a word in
-  //Squirrel to be called from scripts.
+	//Binds a function from C++ to a word in
+	//Squirrel to be called from scripts.
 	sq_pushroottable(v);
 	sq_pushstring(v, key, -1);
 	sq_newclosure(v, func, 0);
@@ -413,17 +428,22 @@ void xyBindAllFunctions(HSQUIRRELVM v) {
 
 	//File IO
 	xyPrint(0, "Embedding file I/O...");
-	xyBindFunc(v, sqFileExists, "fileExists", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqImport, "import", 2, ".s");
 	xyBindFunc(v, sqDoString, "dostr", 2, ".s"); //Doc'd
-	xyBindFunc(v, sqDecodeJSON, "jsonRead", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqMount, "mount", 3, ".sb");
+	xyBindFunc(v, sqUnmount, "unmount", 2, ".s");
 	xyBindFunc(v, sqGetDir, "getdir"); //Doc'd
-	xyBindFunc(v, sqSetDir, "chdir", 2, ".s"); //Doc'd
-	xyBindFunc(v, sqLsDir, "lsdir", 2, ".s"); //Doc'd
-	xyBindFunc(v, sqIsDir, "isdir", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqGetWriteDir, "getWriteDir");
+	xyBindFunc(v, sqGetPrefDir, "getPrefDir", 3, ".ss");
+	xyBindFunc(v, sqSetWriteDir, "setWriteDir", 2, ".s");
+	xyBindFunc(v, sqCreateDir, "createDir", 2, ".s");
+	xyBindFunc(v, sqFileRead, "fileRead", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqFileWrite, "fileWrite", 3, ".ss"); //Doc'd
 	xyBindFunc(v, sqFileAppend, "fileAppend", 3, ".ss"); //Doc'd
-	xyBindFunc(v, sqFileRead, "fileRead", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqFileExists, "fileExists", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqDecodeJSON, "jsonRead", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqLsDir, "lsdir", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqIsDir, "isdir", 2, ".s"); //Doc'd
 
 	//Audio
 	xyPrint(0, "Embedding audio...");

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
 	SDL_ShowCursor(0);
 
 	//Mount the current working directory.
-	xyFSMount(xyGetDir(), true);
+	xyFSMount(xyGetDir(), "/", true);
 
 	//Set the current write directory to a default for Brux.
 	//Can be changed later by the game.
@@ -430,7 +430,7 @@ void xyBindAllFunctions(HSQUIRRELVM v) {
 	xyPrint(0, "Embedding file I/O...");
 	xyBindFunc(v, sqImport, "import", 2, ".s");
 	xyBindFunc(v, sqDoString, "dostr", 2, ".s"); //Doc'd
-	xyBindFunc(v, sqMount, "mount", 3, ".sb"); //Doc'd
+	xyBindFunc(v, sqMount, "mount", 4, ".ssb"); //Doc'd
 	xyBindFunc(v, sqUnmount, "unmount", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqGetDir, "getdir"); //Doc'd
 	xyBindFunc(v, sqGetWriteDir, "getWriteDir"); //Doc'd

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -430,18 +430,18 @@ void xyBindAllFunctions(HSQUIRRELVM v) {
 	xyPrint(0, "Embedding file I/O...");
 	xyBindFunc(v, sqImport, "import", 2, ".s");
 	xyBindFunc(v, sqDoString, "dostr", 2, ".s"); //Doc'd
-	xyBindFunc(v, sqMount, "mount", 3, ".sb");
-	xyBindFunc(v, sqUnmount, "unmount", 2, ".s");
+	xyBindFunc(v, sqMount, "mount", 3, ".sb"); //Doc'd
+	xyBindFunc(v, sqUnmount, "unmount", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqGetDir, "getdir"); //Doc'd
-	xyBindFunc(v, sqGetWriteDir, "getWriteDir");
-	xyBindFunc(v, sqGetPrefDir, "getPrefDir", 3, ".ss");
-	xyBindFunc(v, sqSetWriteDir, "setWriteDir", 2, ".s");
-	xyBindFunc(v, sqCreateDir, "createDir", 2, ".s");
+	xyBindFunc(v, sqGetWriteDir, "getWriteDir"); //Doc'd
+	xyBindFunc(v, sqGetPrefDir, "getPrefDir", 3, ".ss"); //Doc'd
+	xyBindFunc(v, sqSetWriteDir, "setWriteDir", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqCreateDir, "createDir", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqFileRead, "fileRead", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqFileWrite, "fileWrite", 3, ".ss"); //Doc'd
 	xyBindFunc(v, sqFileAppend, "fileAppend", 3, ".ss"); //Doc'd
 	xyBindFunc(v, sqFileExists, "fileExists", 2, ".s"); //Doc'd
-	xyBindFunc(v, sqFileDelete, "fileDelete", 2, ".s");
+	xyBindFunc(v, sqFileDelete, "fileDelete", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqDecodeJSON, "jsonRead", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqLsDir, "lsdir", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqIsDir, "isdir", 2, ".s"); //Doc'd

--- a/rte/main.cpp
+++ b/rte/main.cpp
@@ -441,6 +441,7 @@ void xyBindAllFunctions(HSQUIRRELVM v) {
 	xyBindFunc(v, sqFileWrite, "fileWrite", 3, ".ss"); //Doc'd
 	xyBindFunc(v, sqFileAppend, "fileAppend", 3, ".ss"); //Doc'd
 	xyBindFunc(v, sqFileExists, "fileExists", 2, ".s"); //Doc'd
+	xyBindFunc(v, sqFileDelete, "fileDelete", 2, ".s");
 	xyBindFunc(v, sqDecodeJSON, "jsonRead", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqLsDir, "lsdir", 2, ".s"); //Doc'd
 	xyBindFunc(v, sqIsDir, "isdir", 2, ".s"); //Doc'd

--- a/rte/makefile
+++ b/rte/makefile
@@ -1,4 +1,4 @@
-CFLAGS = -I. -lstdc++ -lSDL2main -lSDL2 -lSDL2_image -lSDL2_gfx -lSDL2_mixer -lSDL2_net -lsquirrel -lsqstdlib -lm --std=c++17
+CFLAGS = -I. -lstdc++ -lSDL2main -lSDL2 -lSDL2_image -lSDL2_gfx -lSDL2_mixer -lSDL2_net -lphysfs -lsquirrel -lsqstdlib -lm --std=c++17
 
 EMCFLAGS = -O3 -I. -lstdc++ -lm --std=c++17
 


### PR DESCRIPTION
Implements the PhysicsFS library into Brux. It provides a "search path", which exposes only selected directories to be allowed to be modified by the application. With the help of PhysicsFS, a few new functions have been added, as well as a way to have the game files stored at the appropriate for the system application data folder.

By default, Brux uses the `brux` (or `brux/brux`) folder, relative to the application data folder of the system, for writing. Games can change this directory by using `setWriteDir()`. The intended way of setting it is `setWriteDir(getPrefDir({org}, {app}))`, which will make the game use an `org/app` directory, relative to the application data folder of the system, for writing.

TODO: ~~Document new/modified functions.~~ [DONE]

Closes #46.