### PR TITLE
Link more libraries statically on Linux using CMake

### DIFF
--- a/.github/workflows/gnu_linux.yml
+++ b/.github/workflows/gnu_linux.yml
@@ -57,7 +57,8 @@ jobs:
             libmodplug-dev:i386 \
             libmpg123-dev:i386 \
             libvorbis-dev:i386 \
-            libopusfile-dev:i386
+            libopusfile-dev:i386 \
+            libzstd-dev:i386
 
       - name: Install 64-bit dependencies
         if: ${{ matrix.arch == 64 }}
@@ -84,7 +85,8 @@ jobs:
             libmodplug-dev \
             libmpg123-dev \
             libvorbis-dev \
-            libopusfile-dev
+            libopusfile-dev \
+            libzstd-dev
 
       - name: Set compiler (gcc)
         run: |

--- a/rte/CMakeLists.txt
+++ b/rte/CMakeLists.txt
@@ -42,8 +42,25 @@ include(ProvideSquirrel)
 
 # If static linking is enabled, link additional libraries
 if(BUILD_STATIC_LIBS)
-  target_link_libraries(SDL2::Image INTERFACE jpeg png tiff webp)
-  target_link_libraries(SDL2::Mixer INTERFACE FLAC fluidsynth modplug mpg123 ogg vorbisfile opusfile)
+  # SDL2::Image libraries
+  find_package(JPEG REQUIRED)
+  find_package(PNG REQUIRED)
+  find_package(TIFF REQUIRED)
+  find_package(LZMA REQUIRED)
+  find_package(zstd REQUIRED)
+  find_package(JBIG REQUIRED)
+  find_package(Deflate REQUIRED)
+  find_package(WebP REQUIRED)
+  target_link_libraries(SDL2::Image INTERFACE ${JPEG_LIBRARIES} ${PNG_LIBRARIES} ${TIFF_LIBRARIES} ${LZMA_LIBRARIES} ${zstd_LIBRARIES} ${JBIG_LIBRARIES} ${Deflate_LIBRARIES} ${WebP_LIBRARIES})
+
+  # SDL2::Mixer libraries
+  find_package(OGG REQUIRED)
+  find_package(FLAC REQUIRED)
+  find_package(Modplug REQUIRED)
+  find_package(MPG123 REQUIRED)
+  find_package(VORBIS REQUIRED)
+  find_package(OpusFile REQUIRED)
+  target_link_libraries(SDL2::Mixer INTERFACE ${FLAC_LIBRARY} fluidsynth ${MODPLUG_LIBRARIES} ${MPG123_LIBRARIES} ${VORBIS_LIBRARIES} ${OPUSFILE_LIBRARIES} ${OGG_LIBRARIES})
 endif()
 
 # Include additional scripts

--- a/rte/cmake/Copyright.txt
+++ b/rte/cmake/Copyright.txt
@@ -1,0 +1,136 @@
+CMake - Cross Platform Makefile Generator
+Copyright 2000-2023 Kitware, Inc. and Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of Kitware, Inc. nor the names of Contributors
+  may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+
+The following individuals and institutions are among the Contributors:
+
+* Aaron C. Meadows <cmake@shadowguarddev.com>
+* Adriaan de Groot <groot@kde.org>
+* Aleksey Avdeev <solo@altlinux.ru>
+* Alexander Neundorf <neundorf@kde.org>
+* Alexander Smorkalov <alexander.smorkalov@itseez.com>
+* Alexey Sokolov <sokolov@google.com>
+* Alex Merry <alex.merry@kde.org>
+* Alex Turbov <i.zaufi@gmail.com>
+* Andreas Pakulat <apaku@gmx.de>
+* Andreas Schneider <asn@cryptomilk.org>
+* André Rigland Brodtkorb <Andre.Brodtkorb@ifi.uio.no>
+* Axel Huebl, Helmholtz-Zentrum Dresden - Rossendorf
+* Benjamin Eikel
+* Bjoern Ricks <bjoern.ricks@gmail.com>
+* Brad Hards <bradh@kde.org>
+* Christopher Harvey
+* Christoph Grüninger <foss@grueninger.de>
+* Clement Creusot <creusot@cs.york.ac.uk>
+* Daniel Blezek <blezek@gmail.com>
+* Daniel Pfeifer <daniel@pfeifer-mail.de>
+* Dawid Wróbel <me@dawidwrobel.com>
+* Enrico Scholz <enrico.scholz@informatik.tu-chemnitz.de>
+* Eran Ifrah <eran.ifrah@gmail.com>
+* Esben Mose Hansen, Ange Optimization ApS
+* Geoffrey Viola <geoffrey.viola@asirobots.com>
+* Google Inc
+* Gregor Jasny
+* Helio Chissini de Castro <helio@kde.org>
+* Ilya Lavrenov <ilya.lavrenov@itseez.com>
+* Insight Software Consortium <insightsoftwareconsortium.org>
+* Intel Corporation <www.intel.com>
+* Jan Woetzel
+* Jordan Williams <jordan@jwillikers.com>
+* Julien Schueller
+* Kelly Thompson <kgt@lanl.gov>
+* Konstantin Podsvirov <konstantin@podsvirov.pro>
+* Laurent Montel <montel@kde.org>
+* Mario Bensi <mbensi@ipsquad.net>
+* Martin Gräßlin <mgraesslin@kde.org>
+* Mathieu Malaterre <mathieu.malaterre@gmail.com>
+* Matthaeus G. Chajdas
+* Matthias Kretz <kretz@kde.org>
+* Matthias Maennich <matthias@maennich.net>
+* Michael Hirsch, Ph.D. <www.scivision.co>
+* Michael Stürmer
+* Miguel A. Figueroa-Villanueva
+* Mike Durso <rbprogrammer@gmail.com>
+* Mike Jackson
+* Mike McQuaid <mike@mikemcquaid.com>
+* Nicolas Bock <nicolasbock@gmail.com>
+* Nicolas Despres <nicolas.despres@gmail.com>
+* Nikita Krupen'ko <krnekit@gmail.com>
+* NVIDIA Corporation <www.nvidia.com>
+* OpenGamma Ltd. <opengamma.com>
+* Patrick Stotko <stotko@cs.uni-bonn.de>
+* Per Øyvind Karlsen <peroyvind@mandriva.org>
+* Peter Collingbourne <peter@pcc.me.uk>
+* Petr Gotthard <gotthard@honeywell.com>
+* Philip Lowman <philip@yhbt.com>
+* Philippe Proulx <pproulx@efficios.com>
+* Raffi Enficiaud, Max Planck Society
+* Raumfeld <raumfeld.com>
+* Roger Leigh <rleigh@codelibre.net>
+* Rolf Eike Beer <eike@sf-mail.de>
+* Roman Donchenko <roman.donchenko@itseez.com>
+* Roman Kharitonov <roman.kharitonov@itseez.com>
+* Ruslan Baratov
+* Sebastian Holtermann <sebholt@xwmw.org>
+* Stephen Kelly <steveire@gmail.com>
+* Sylvain Joubert <joubert.sy@gmail.com>
+* The Qt Company Ltd.
+* Thomas Sondergaard <ts@medical-insight.com>
+* Tobias Hunger <tobias.hunger@qt.io>
+* Todd Gamblin <tgamblin@llnl.gov>
+* Tristan Carel
+* University of Dundee
+* Vadim Zhukov
+* Will Dicharry <wdicharry@stellarscience.com>
+
+See version control history for details of individual contributions.
+
+The above copyright and license notice applies to distributions of
+CMake in source and binary form.  Third-party software packages supplied
+with CMake under compatible licenses provide their own copyright notices
+documented in corresponding subdirectories or source files.
+
+------------------------------------------------------------------------------
+
+CMake was initially developed by Kitware with the following sponsorship:
+
+ * National Library of Medicine at the National Institutes of Health
+   as part of the Insight Segmentation and Registration Toolkit (ITK).
+
+ * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
+   Visualization Initiative.
+
+ * National Alliance for Medical Image Computing (NAMIC) is funded by the
+   National Institutes of Health through the NIH Roadmap for Medical Research,
+   Grant U54 EB005149.
+
+ * Kitware, Inc.

--- a/rte/cmake/FindDeflate.cmake
+++ b/rte/cmake/FindDeflate.cmake
@@ -1,0 +1,119 @@
+# ORIGIN: https://fossies.org/linux/tiff/cmake/FindDeflate.cmake
+#
+#
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindDeflate
+--------
+
+Find the native Deflate includes and library.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines :prop_tgt:`IMPORTED` target ``Deflate::Deflate``, if
+Deflate has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+::
+
+  Deflate_INCLUDE_DIRS   - where to find deflate.h, etc.
+  Deflate_LIBRARIES      - List of libraries when using deflate.
+  Deflate_FOUND          - True if deflate found.
+
+::
+
+  Deflate_VERSION_STRING - The version of deflate found (x.y.z)
+  Deflate_VERSION_MAJOR  - The major version of deflate
+  Deflate_VERSION_MINOR  - The minor version of deflate
+
+  Debug and Release variants are found separately.
+#]=======================================================================]
+
+# Standard names to search for
+set(Deflate_NAMES deflate deflatestatic)
+set(Deflate_NAMES_DEBUG deflated deflatestaticd)
+
+find_path(Deflate_INCLUDE_DIR
+          NAMES libdeflate.h
+          PATH_SUFFIXES include)
+
+set(Deflate_OLD_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
+# Library has a "lib" prefix even on Windows.
+set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "")
+
+# Allow Deflate_LIBRARY to be set manually, as the location of the deflate library
+if(NOT Deflate_LIBRARY)
+  find_library(Deflate_LIBRARY_RELEASE
+               NAMES ${Deflate_NAMES}
+               PATH_SUFFIXES lib)
+  find_library(Deflate_LIBRARY_DEBUG
+               NAMES ${Deflate_NAMES_DEBUG}
+               PATH_SUFFIXES lib)
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(Deflate)
+endif()
+
+set(CMAKE_FIND_LIBRARY_PREFIXES "${Deflate_OLD_FIND_LIBRARY_PREFIXES}")
+
+unset(Deflate_NAMES)
+unset(Deflate_NAMES_DEBUG)
+unset(Deflate_OLD_FIND_LIBRARY_PREFIXES)
+
+mark_as_advanced(Deflate_INCLUDE_DIR)
+
+if(Deflate_INCLUDE_DIR AND EXISTS "${Deflate_INCLUDE_DIR}/deflate.h")
+    file(STRINGS "${Deflate_INCLUDE_DIR}/libdeflate.h" Deflate_H REGEX "^#define LIBDEFLATE_VERSION_STRING\s+\"[^\"]*\"$")
+
+    string(REGEX REPLACE "^.*Deflate_VERSION \"([0-9]+).*$" "\\1" Deflate_MAJOR_VERSION "${Deflate_H}")
+    string(REGEX REPLACE "^.*Deflate_VERSION \"[0-9]+\\.([0-9]+).*$" "\\1" Deflate_MINOR_VERSION  "${Deflate_H}")
+    set(Deflate_VERSION_STRING "${Deflate_MAJOR_VERSION}.${Deflate_MINOR_VERSION}")
+
+    set(Deflate_MAJOR_VERSION "${Deflate_VERSION_MAJOR}")
+    set(Deflate_MINOR_VERSION "${Deflate_VERSION_MINOR}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Deflate
+        REQUIRED_VARS Deflate_LIBRARY Deflate_INCLUDE_DIR
+        VERSION_VAR Deflate_VERSION_STRING)
+
+if(Deflate_FOUND)
+    set(Deflate_INCLUDE_DIRS ${Deflate_INCLUDE_DIR})
+
+    if(NOT Deflate_LIBRARIES)
+        set(Deflate_LIBRARIES ${Deflate_LIBRARY})
+    endif()
+
+    if(NOT TARGET Deflate::Deflate)
+        add_library(Deflate::Deflate UNKNOWN IMPORTED)
+        set_target_properties(Deflate::Deflate PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${Deflate_INCLUDE_DIRS}")
+
+        if(Deflate_LIBRARY_RELEASE)
+            set_property(TARGET Deflate::Deflate APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(Deflate::Deflate PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${Deflate_LIBRARY_RELEASE}")
+        endif()
+
+        if(Deflate_LIBRARY_DEBUG)
+            set_property(TARGET Deflate::Deflate APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(Deflate::Deflate PROPERTIES
+                    IMPORTED_LOCATION_DEBUG "${Deflate_LIBRARY_DEBUG}")
+        endif()
+
+        if(NOT Deflate_LIBRARY_RELEASE AND NOT Deflate_LIBRARY_DEBUG)
+            set_target_properties(Deflate::Deflate PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${Deflate_LIBRARY}")
+        endif()
+    endif()
+endif()

--- a/rte/cmake/FindFLAC.cmake
+++ b/rte/cmake/FindFLAC.cmake
@@ -1,0 +1,20 @@
+# ORIGIN: https://github.com/SFML/SFML/blob/master/cmake/Modules/FindFLAC.cmake
+#
+#
+# Try to find FLAC libraries and include paths.
+# Once done this will define
+#
+# FLAC_FOUND
+# FLAC_INCLUDE_DIR
+# FLAC_LIBRARY
+#
+
+find_path(FLAC_INCLUDE_DIR FLAC/all.h)
+find_path(FLAC_INCLUDE_DIR FLAC/stream_decoder.h)
+
+find_library(FLAC_LIBRARY NAMES FLAC)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FLAC DEFAULT_MSG FLAC_LIBRARY FLAC_INCLUDE_DIR)
+
+mark_as_advanced(FLAC_INCLUDE_DIR FLAC_LIBRARY)

--- a/rte/cmake/FindJBIG.cmake
+++ b/rte/cmake/FindJBIG.cmake
@@ -1,0 +1,84 @@
+# ORIGIN: https://github.com/ufz/tiff/blob/master/cmake/Modules/FindJBIG.cmake
+#
+#
+# - Find JBIG-KIT
+# Find the native JBIG-KIT includes and library.
+# Once done this will define
+#
+#  JBIG_INCLUDE_DIRS - where to find jbig.h and the required dependencies
+#  JBIG_LIBRARIES    - list of libraries when using JBIG-KIT
+#  JBIG_FOUND        - true if JBIG-KIT found
+#
+#  JBIG_VERSION_STRING - The version of JBIG-KIT found (x.y)
+#  JBIG_VERSION_MAJOR  - The major version of JBIG-KIT
+#  JBIG_VERSION_MINOR  - The minor version of JBIG-KIT
+#
+# An includer may set JBIG_ROOT to a JBIG-KIT installation root to tell
+# this module where to look.
+#
+#=============================================================================
+# Edgar Velázquez-Armendáriz, Cornell University (cs.cornell.edu - eva5)
+# Distributed under the OSI-approved MIT License (the "License")
+# 
+# Copyright (c) 2011 Program of Computer Graphics, Cornell University
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#=============================================================================
+
+include(FindPackageHandleStandardArgs)
+
+set(_JBIG_SEARCHES)
+
+# Search JBIG_ROOT first if it is set.
+if(JBIG_ROOT)
+  set(_JBIG_SEARCHES PATHS ${JBIG_ROOT} NO_DEFAULT_PATH)
+endif()
+
+set(JBIG_NAMES ${JBIG_NAMES} jbig)
+
+find_path(JBIG_INCLUDE_DIR NAMES jbig.h        ${_JBIG_SEARCHES} PATH_SUFFIXES include)
+find_library(JBIG_LIBRARY  NAMES ${JBIG_NAMES} ${_JBIG_SEARCHES} PATH_SUFFIXES lib)
+
+mark_as_advanced(JBIG_LIBRARY JBIG_INCLUDE_DIR)
+
+# Version detection based on the default FindZLIB.cmake module
+if(JBIG_INCLUDE_DIR AND EXISTS "${JBIG_INCLUDE_DIR}/jbig.h")
+  file(STRINGS "${JBIG_INCLUDE_DIR}/jbig.h" JBIG_H REGEX "^#define JBG_VERSION[ \\t]+\"[^\"]*\"$")
+
+  string(REGEX REPLACE "^.*JBG_VERSION[ \\t]+\"([0-9]+).*$" "\\1" JBIG_VERSION_MAJOR "${JBIG_H}")
+  string(REGEX REPLACE "^.*JBG_VERSION[ \\t]+\"[0-9]+\\.([0-9]+).*$" "\\1" JBIG_VERSION_MINOR  "${JBIG_H}")
+  set(JBIG_VERSION_STRING "${JBIG_VERSION_MAJOR}.${JBIG_VERSION_MINOR}")
+  
+  # only append a PATCH version if it exists:
+  set(JBIG_VERSION_PATCH "")
+  if("${JBIG_H}" MATCHES "^.*JBG_VERSION[ \\t]+\"[0-9]+\\.[0-9]+\\.([0-9]+).*$")
+    set(JBIG_VERSION_PATCH  "${CMAKE_MATCH_1}")
+    set(JBIG_VERSION_STRING "${JBIG_VERSION_STRING}.${JBIG_VERSION_PATCH}")
+  endif()  
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set JBIG_FOUND to TRUE if 
+# all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(JBIG REQUIRED_VARS JBIG_LIBRARY JBIG_INCLUDE_DIR
+                                       VERSION_VAR JBIG_VERSION_STRING)
+
+if(JBIG_FOUND)
+  set(JBIG_LIBRARIES ${JBIG_LIBRARY})
+  set(JBIG_INCLUDE_DIRS ${JBIG_INCLUDE_DIR})
+endif()

--- a/rte/cmake/FindLZMA.cmake
+++ b/rte/cmake/FindLZMA.cmake
@@ -1,0 +1,55 @@
+# ORIGIN: https://github.com/LuaDist/libarchive/blob/master/build/cmake/FindLZMA.cmake
+#
+#
+# - Find lzma and lzmadec
+# Find the native LZMA includes and library
+#
+#  LZMA_INCLUDE_DIR    - where to find lzma.h, etc.
+#  LZMA_LIBRARIES      - List of libraries when using liblzma.
+#  LZMA_FOUND          - True if liblzma found.
+#  LZMADEC_INCLUDE_DIR - where to find lzmadec.h, etc.
+#  LZMADEC_LIBRARIES   - List of libraries when using liblzmadec.
+#  LZMADEC_FOUND       - True if liblzmadec found.
+
+IF (LZMA_INCLUDE_DIR)
+  # Already in cache, be silent
+  SET(LZMA_FIND_QUIETLY TRUE)
+ENDIF (LZMA_INCLUDE_DIR)
+
+FIND_PATH(LZMA_INCLUDE_DIR lzma.h)
+FIND_LIBRARY(LZMA_LIBRARY NAMES lzma )
+
+# handle the QUIETLY and REQUIRED arguments and set LZMA_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZMA DEFAULT_MSG LZMA_LIBRARY LZMA_INCLUDE_DIR)
+
+IF(LZMA_FOUND)
+  SET( LZMA_LIBRARIES ${LZMA_LIBRARY} )
+ELSE(LZMA_FOUND)
+  SET( LZMA_LIBRARIES )
+
+  IF (LZMADEC_INCLUDE_DIR)
+    # Already in cache, be silent
+    SET(LZMADEC_FIND_QUIETLY TRUE)
+  ENDIF (LZMADEC_INCLUDE_DIR)
+
+  FIND_PATH(LZMADEC_INCLUDE_DIR lzmadec.h)
+  FIND_LIBRARY(LZMADEC_LIBRARY NAMES lzmadec )
+
+  # handle the QUIETLY and REQUIRED arguments and set LZMADEC_FOUND to TRUE if 
+  # all listed variables are TRUE
+  INCLUDE(FindPackageHandleStandardArgs)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZMADEC DEFAULT_MSG LZMADEC_LIBRARY
+    LZMADEC_INCLUDE_DIR)
+
+  IF(LZMADEC_FOUND)
+    SET( LZMADEC_LIBRARIES ${LZMADEC_LIBRARY} )
+  ELSE(LZMADEC_FOUND)
+    SET( LZMADEC_LIBRARIES )
+  ENDIF(LZMADEC_FOUND)
+ENDIF(LZMA_FOUND)
+
+
+MARK_AS_ADVANCED( LZMA_LIBRARY LZMA_INCLUDE_DIR
+  LZMADEC_LIBRARY LZMADEC_INCLUDE_DIR )

--- a/rte/cmake/FindMPG123.cmake
+++ b/rte/cmake/FindMPG123.cmake
@@ -1,0 +1,31 @@
+# ORIGIN: https://github.com/rheit/zdoom/blob/master/FindMPG123.cmake
+#
+#
+# - Find mpg123
+# Find the native mpg123 includes and library
+#
+#  MPG123_INCLUDE_DIR - where to find mpg123.h
+#  MPG123_LIBRARIES   - List of libraries when using mpg123.
+#  MPG123_FOUND       - True if mpg123 found.
+
+IF(MPG123_INCLUDE_DIR AND MPG123_LIBRARIES)
+  # Already in cache, be silent
+  SET(MPG123_FIND_QUIETLY TRUE)
+ENDIF(MPG123_INCLUDE_DIR AND MPG123_LIBRARIES)
+
+FIND_PATH(MPG123_INCLUDE_DIR mpg123.h
+          PATHS "${MPG123_DIR}"
+          PATH_SUFFIXES include
+          )
+
+FIND_LIBRARY(MPG123_LIBRARIES NAMES mpg123 mpg123-0
+             PATHS "${MPG123_DIR}"
+             PATH_SUFFIXES lib
+             )
+
+# MARK_AS_ADVANCED(MPG123_LIBRARIES MPG123_INCLUDE_DIR)
+
+# handle the QUIETLY and REQUIRED arguments and set MPG123_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(MPG123 DEFAULT_MSG MPG123_LIBRARIES MPG123_INCLUDE_DIR)

--- a/rte/cmake/FindModplug.cmake
+++ b/rte/cmake/FindModplug.cmake
@@ -1,0 +1,24 @@
+# ORIGIN: https://github.com/xbmc/audiodecoder.modplug/blob/Nexus/FindModplug.cmake
+#
+#
+# - Try to find modplug
+# Once done this will define
+#
+# MODPLUG_FOUND - system has libmodplug
+# MODPLUG_INCLUDE_DIRS - the libmodplug include directory
+# MODPLUG_LIBRARIES - The libmodplug libraries
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_MODPLUG libmodplug QUIET)
+endif()
+
+find_path(MODPLUG_INCLUDE_DIRS libmodplug/modplug.h
+                               PATHS ${PC_MODPLUG_INCLUDEDIR})
+find_library(MODPLUG_LIBRARIES NAMES modplug
+                               PATHS ${PC_MODPLUG_LIBDIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Modplug REQUIRED_VARS MODPLUG_INCLUDE_DIRS MODPLUG_LIBRARIES)
+
+mark_as_advanced(MODPLUG_INCLUDE_DIRS MODPLUG_LIBRARIES)

--- a/rte/cmake/FindOGG.cmake
+++ b/rte/cmake/FindOGG.cmake
@@ -1,0 +1,30 @@
+# ORIGIN: https://github.com/kcat/alure/blob/master/cmake/FindOgg.cmake
+#
+#
+# - FindOgg.cmake
+# Find the native ogg includes and libraries
+#
+# OGG_INCLUDE_DIRS - where to find ogg/ogg.h, etc.
+# OGG_LIBRARIES - List of libraries when using ogg.
+# OGG_FOUND - True if ogg found.
+
+if(OGG_INCLUDE_DIR AND OGG_LIBRARY)
+    # Already in cache, be silent
+    set(OGG_FIND_QUIETLY TRUE)
+endif(OGG_INCLUDE_DIR AND OGG_LIBRARY)
+
+find_path(OGG_INCLUDE_DIR ogg/ogg.h)
+
+# MSVC built ogg may be named ogg_static.
+# The provided project files name the library with the lib prefix.
+find_library(OGG_LIBRARY NAMES ogg ogg_static libogg libogg_static)
+
+# Handle the QUIETLY and REQUIRED arguments and set OGG_FOUND
+# to TRUE if all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OGG DEFAULT_MSG OGG_LIBRARY OGG_INCLUDE_DIR)
+
+if(OGG_FOUND)
+    set(OGG_LIBRARIES ${OGG_LIBRARY})
+    set(OGG_INCLUDE_DIRS ${OGG_INCLUDE_DIR})
+endif(OGG_FOUND)

--- a/rte/cmake/FindOpusFile.cmake
+++ b/rte/cmake/FindOpusFile.cmake
@@ -1,0 +1,34 @@
+# ORIGIN: https://github.com/Cog-Invasion-Online/cio-panda3d/blob/master/cmake/modules/FindOpusFile.cmake
+#
+#
+# Filename: FindOpusFile.cmake
+# Authors: CFSworks (13 Jan, 2019)
+#
+# Usage:
+#   find_package(OpusFile [REQUIRED] [QUIET])
+#
+# Once done this will define:
+#   OPUSFILE_FOUND        - system has Ogg and opusfile
+#   OPUSFILE_INCLUDE_DIRS - the include directory/ies containing opus/ and ogg/
+#   OPUSFILE_LIBRARIES    - the paths to the opus and opusfile libraries
+#
+
+# Find Opus
+find_path(OPUS_INCLUDE_DIR NAMES "opus/opusfile.h")
+
+find_library(OPUS_opus_LIBRARY NAMES "opus")
+find_library(OPUS_opusfile_LIBRARY NAMES "opusfile")
+
+mark_as_advanced(OPUS_INCLUDE_DIR OPUS_opus_LIBRARY OPUS_opusfile_LIBRARY)
+
+# Define output variables
+set(OPUSFILE_INCLUDE_DIRS ${OPUS_INCLUDE_DIR} "${OPUS_INCLUDE_DIR}/opus")
+if(NOT OGG_INCLUDE_DIR STREQUAL OPUS_INCLUDE_DIR)
+  list(APPEND OPUSFILE_INCLUDE_DIRS ${OGG_INCLUDE_DIR})
+endif()
+set(OPUSFILE_LIBRARIES ${OPUS_opusfile_LIBRARY} ${OPUS_opus_LIBRARY} ${OGG_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpusFile DEFAULT_MSG
+  OPUS_opusfile_LIBRARY
+  OPUS_INCLUDE_DIR OPUS_opus_LIBRARY OPUS_opusfile_LIBRARY)

--- a/rte/cmake/FindVORBIS.cmake
+++ b/rte/cmake/FindVORBIS.cmake
@@ -1,0 +1,37 @@
+# ORIGIN: https://github.com/kcat/alure/blob/master/cmake/FindVorbis.cmake
+#
+#
+# - FindVorbis.cmake
+# Find the native vorbis includes and libraries
+#
+# VORBIS_INCLUDE_DIRS - where to find vorbis/vorbis.h, etc.
+# VORBIS_LIBRARIES - List of libraries when using vorbis(file).
+# VORBIS_FOUND - True if vorbis found.
+
+if(VORBIS_INCLUDE_DIR AND VORBIS_LIBRARY AND VORBISFILE_LIBRARY)
+    # Already in cache, be silent
+    set(VORBIS_FIND_QUIETLY TRUE)
+endif(VORBIS_INCLUDE_DIR AND VORBIS_LIBRARY AND VORBISFILE_LIBRARY)
+
+find_path(VORBIS_INCLUDE_DIR vorbis/vorbisfile.h)
+
+# MSVC built vorbis may be named vorbis_static
+# The provided project files name the library with the lib prefix.
+find_library(VORBIS_LIBRARY
+    NAMES vorbis vorbis_static libvorbis libvorbis_static
+)
+find_library(VORBISFILE_LIBRARY
+    NAMES vorbisfile vorbisfile_static libvorbisfile libvorbisfile_static
+)
+
+# Handle the QUIETLY and REQUIRED arguments and set VORBIS_FOUND
+# to TRUE if all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(VORBIS DEFAULT_MSG
+    VORBISFILE_LIBRARY VORBIS_LIBRARY VORBIS_INCLUDE_DIR
+)
+
+if(VORBIS_FOUND)
+    set(VORBIS_LIBRARIES ${VORBISFILE_LIBRARY} ${VORBIS_LIBRARY})
+    set(VORBIS_INCLUDE_DIRS ${VORBIS_INCLUDE_DIR})
+endif(VORBIS_FOUND)

--- a/rte/cmake/FindWebP.cmake
+++ b/rte/cmake/FindWebP.cmake
@@ -1,0 +1,94 @@
+# ORIGIN: https://gitlab.com/libtiff/libtiff/-/blob/master/cmake/FindWebP.cmake
+#
+#
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindWebP
+--------
+
+Find the native WebP includes and library.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines :prop_tgt:`IMPORTED` target ``WebP::WebP``, if
+WebP has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+::
+
+  WebP_INCLUDE_DIRS   - where to find webp/*.h, etc.
+  WebP_LIBRARIES      - List of libraries when using webp.
+  WebP_FOUND          - True if webp found.
+
+  Debug and Release variants are found separately.
+#]=======================================================================]
+
+# Standard names to search for
+set(WebP_NAMES webp)
+set(WebP_NAMES_DEBUG webpd)
+
+find_path(WebP_INCLUDE_DIR
+          NAMES webp/decode.h
+          PATH_SUFFIXES include)
+
+# Allow WebP_LIBRARY to be set manually, as the location of the webp library
+if(NOT WebP_LIBRARY)
+  find_library(WebP_LIBRARY_RELEASE
+               NAMES ${WebP_NAMES}
+               PATH_SUFFIXES lib)
+  find_library(WebP_LIBRARY_DEBUG
+               NAMES ${WebP_NAMES_DEBUG}
+               PATH_SUFFIXES lib)
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(WebP)
+endif()
+
+unset(WebP_NAMES)
+unset(WebP_NAMES_DEBUG)
+
+mark_as_advanced(WebP_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(WebP
+        REQUIRED_VARS WebP_LIBRARY WebP_INCLUDE_DIR)
+
+if(WebP_FOUND)
+    set(WebP_INCLUDE_DIRS ${WebP_INCLUDE_DIR})
+
+    if(NOT WebP_LIBRARIES)
+        set(WebP_LIBRARIES ${WebP_LIBRARY})
+    endif()
+
+    if(NOT TARGET WebP::WebP)
+        add_library(WebP::WebP UNKNOWN IMPORTED)
+        set_target_properties(WebP::WebP PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${WebP_INCLUDE_DIRS}")
+
+        if(WebP_LIBRARY_RELEASE)
+            set_property(TARGET WebP::WebP APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(WebP::WebP PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${WebP_LIBRARY_RELEASE}")
+        endif()
+
+        if(WebP_LIBRARY_DEBUG)
+            set_property(TARGET WebP::WebP APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(WebP::WebP PROPERTIES
+                    IMPORTED_LOCATION_DEBUG "${WebP_LIBRARY_DEBUG}")
+        endif()
+
+        if(NOT WebP_LIBRARY_RELEASE AND NOT WebP_LIBRARY_DEBUG)
+            set_target_properties(WebP::WebP PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${WebP_LIBRARY}")
+        endif()
+    endif()
+endif()

--- a/rte/cmake/Findzstd.cmake
+++ b/rte/cmake/Findzstd.cmake
@@ -1,0 +1,32 @@
+# ORIGIN: https://github.com/facebook/rocksdb/blob/main/cmake/modules/Findzstd.cmake
+#
+#
+# - Find zstd
+# Find the zstd compression library and includes
+#
+# zstd_INCLUDE_DIRS - where to find zstd.h, etc.
+# zstd_LIBRARIES - List of libraries when using zstd.
+# zstd_FOUND - True if zstd found.
+
+find_path(zstd_INCLUDE_DIRS
+  NAMES zstd.h
+  HINTS ${zstd_ROOT_DIR}/include)
+
+find_library(zstd_LIBRARIES
+  NAMES zstd
+  HINTS ${zstd_ROOT_DIR}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(zstd DEFAULT_MSG zstd_LIBRARIES zstd_INCLUDE_DIRS)
+
+mark_as_advanced(
+  zstd_LIBRARIES
+  zstd_INCLUDE_DIRS)
+
+if(zstd_FOUND AND NOT (TARGET zstd::zstd))
+  add_library (zstd::zstd UNKNOWN IMPORTED)
+  set_target_properties(zstd::zstd
+    PROPERTIES
+      IMPORTED_LOCATION ${zstd_LIBRARIES}
+      INTERFACE_INCLUDE_DIRECTORIES ${zstd_INCLUDE_DIRS})
+endif()

--- a/rte/cmake/ProvidePhysFS.cmake
+++ b/rte/cmake/ProvidePhysFS.cmake
@@ -1,4 +1,4 @@
-# File originates from https://github.com/SuperTux/supertux/blob/master/mk/cmake/SuperTux/ProvidePhysfs.cmake
+# ORIGIN: https://github.com/SuperTux/supertux/blob/master/mk/cmake/SuperTux/ProvidePhysfs.cmake
 
 find_package(PhysFS)
 

--- a/rte/cmake/ProvideSquirrel.cmake
+++ b/rte/cmake/ProvideSquirrel.cmake
@@ -1,4 +1,4 @@
-# File originates from https://github.com/SuperTux/supertux/blob/master/mk/cmake/SuperTux/ProvideSquirrel.cmake
+# ORIGIN: https://github.com/SuperTux/supertux/blob/master/mk/cmake/SuperTux/ProvideSquirrel.cmake
 
 option(USE_SYSTEM_SQUIRREL "Use preinstalled squirrel if available" ON)
 


### PR DESCRIPTION
Allows for statically linking more libraries, on which SDL2_image and SDL2_mixer depend. Updates the GNU/Linux workflow.

Performed a test on a fresh Linux Mint install to see which libraries are required to be installed. The only ones seem to be `libfluidsynth-dev` and `libmodplug-dev`.