### PR TITLE
Implement a function-based loop system

### DIFF
--- a/docs/en/input.md
+++ b/docs/en/input.md
@@ -45,6 +45,10 @@
 
   Returns if the exit button on the window or the OS's exit shortcut has been pressed.
 
+* <a name="quitGame"></a>**`quitGame()`**
+
+  Sets gvQuit to true, causing the game to exit.
+
 * <a name="joyCount"></a>**`joyCount()`**
 
   Returns number of gamepads detected.

--- a/docs/en/tutorials/hello-world.md
+++ b/docs/en/tutorials/hello-world.md
@@ -29,20 +29,24 @@ You may be wondering why the file path for background.png uses a forward slash i
 
 When you call the function `loadImage()`, it *returns* a value, meaning that the point where it was called becomes a value. For instance, if you typed `local x = mouseX();`, and the X position of the mouse was 42, it would be as though the code had been written `local x = 42;`. The semicolon at the end of each line says that the statement has ended and the system can move onto the next piece of code. Some languages will allow a line break to do the same, but if a language supports semicolons, then it's safer to use them. Currently, `image` has been assigned to a number, which is the number of background.png's index in XYG's memory. The image data itself is not stored in the variable. The reason why we don't store actual image data in the variable is so that muliple variables with the same value will not store copies of the image for each one.
 
-Now that we have the image loaded, we can draw it to the screen. The function to do this is `drawImage()`. However, just calling this function will not make the window show the image. We need to call `update()` to make the screen refresh and show its contents. Add these two lines to the end:
+Now that we have the image loaded, we can draw it to the screen. The function to do this is `drawImage()`.
+
+However, just calling this function will not make the window show the image. We need to create a render function to tell Brux GDK to run our drawImage() call and then update the window for each frame:
 
 ```
-drawImage(image, 0, 0);
-update();
+::gameRender <- function () {
+	drawImage(image, 0, 0);
+}
 ```
 
-Run this code, and what do you see? It just blinked in and out, right? That's because computers take *everything* literally. It loaded the image, drew it, put it on screen, and said "I'm done," and quit. We have to tell it to keep the image up for a while. After `update()`, we use `wait()` to keep things as they are for a while. `wait()` counts how long it should wait in miliseconds, so to wait for a full second, we use a value of 1000. Our code should look like this now:
+Our code should look like this now:
 
 ```
 local image = loadImage("res/background.png");
-drawImage(image, 0, 0);
-update();
-wait(1000);
+
+::gameRender <- function () {
+	drawImage(image, 0, 0);
+}
 ```
 
-And now you've written your first program in XYG! Yeah, it's not that much, but we'll be making more in later tutorials.
+And now you've written your first game with Brux GDK! Yeah, it's not that much, but we'll be making more in later tutorials.

--- a/docs/en/tutorials/main-loop.md
+++ b/docs/en/tutorials/main-loop.md
@@ -2,45 +2,57 @@
 
 ----
 
-The first lesson showed you how to make an image that stays on the screen for a second, but what if you wanted to leave it up for as long as you wanted and quit only when you told it to quit? For that, we need to have the program check over and over if the user has hit escape for each frame, and then quit when it sees the key has been pressed. For this, we'll need another variable called `quit`. Add it to the list of variables at the top of your program.
+The first lesson showed you how to make an image and show it on the screen with `gameRender`.
+
+`gameRender` is a new feature in Brux GDK, and was created to replace the old convention of creating a loop.
+
+The example code you created in the first lesson would look like this in older versions of Brux GDK:
 
 ```
 local image = loadImage("res/background.png");
-local quit = false;
-```
 
-Now we will make our main program loop. For this, we are going to use what's called a `while` loop. A `while` takes an argument much like the functions you used before. For each time the loop runs, it will check that argument, and if it's still true, the loop happens, and stops when the argument becomes false. If you were to write `while(true)`, your loop would run forever, since `true` is a constant, and will never change. Move your earlier code into a `while` loop, and use `!quit` as the condition. `!` means "not", and will switch variables between `true` and `false`. It's not quite as simple as that, but that's a good enough explanation for now.
-
-```
-while(!quit){
+while (!getQuit()) {
 	drawImage(image, 0, 0);
 	update();
-	wait(10);
-};
+}
 ```
 
-As it is now, this loop will still never quit. We need to fix that. It's time to start using the keyboard!
+However, the old loop-based method is now deprecated and the handler function method is used instead.
 
-To check if a key is down, we use `keyDown()`, but if we want to check if a key was just pressed, as opposed to still being held, we use `keyPress()`. Both will work just fine in this situation. The argument it takes is a constant known as a key code. It equals the number used to identify the key on a keyboard. In this case, we use `k_escape`. Add this to the end of your loop.
+There are 3 handler functions that you can create:
+
+- gameRender is run on each frame for rendering the game, which you've already used in the first lesson.
+- gameUpdate is run on each frame for updating the game's current state (e.g physics updates).
+- gameExit is run after the game is closed.
+
+You can run `quitGame()` to exit the game. To demonstrate this, let's make it close when we press the escape key.
+
+To check if a key is down, we use `keyDown()`, but if we want to check if a key was just pressed, as opposed to still being held, we use `keyPress()`. Both will work just fine in this situation. The argument it takes is a constant known as a key code. It equals the number used to identify the key on a keyboard. In this case, we use `k_escape`.
+
+To add this to your game, create a new function named `gameUpdate` with the check in it:
 
 ```
-	if(keyPress(k_escape)) quit = true;
+::gameUpdate <- function () {
+	if (keyPress(k_escape)) {
+		quitGame()
+	}
+}
 ```
 
-Now our whole program should look like this:
+Now run it again. The picture will stay up until you hit escape or press the window close button to close it. Remember, you must include `update()` in your main loop. Without it, not only will your program not redraw the screen, it won't listen for keyboard updates, meaning hitting escape won't work.
+
+Your code should now look like this:
 
 ```
 local image = loadImage("res/background.png");
-local quit = false;
 
-while(!quit){
+::gameRender <- function () {
 	drawImage(image, 0, 0);
+}
 
-	if(keyPress(k_escape)) quit = true;
-
-	update();
-	wait(10);
-};
+::gameUpdate <- function () {
+	if (keyPress(k_escape)) {
+		quitGame();
+	}
+}
 ```
-
-Run it again. The picture will stay up until you hit escape to close it. Remember, you must include `update()` in your main loop. Without it, not only will your program not redraw the screen, it won't listen for keyboard updates, meaning hitting escape won't work.

--- a/docs/en/tutorials/multi-files.md
+++ b/docs/en/tutorials/multi-files.md
@@ -10,16 +10,16 @@ Rewrite your script so it looks like this:
 
 ```
 ::image <- loadImage("res/background.png");
-::quit <- false;
 
-while(!quit){
+::gameRender <- function () {
 	drawImage(image, 0, 0);
+}
 
-	if(keyPress(k_escape)) quit = true;
-
-	update();
-	wait(10);
-};
+::gameUpdate <- function () {
+	if (keyPress(k_escape)) {
+		quitGame();
+	}
+}
 ```
 
 The double colon `::` is used to specify a scope you want to work with. With nothing before it, it points to the global scope, which is what we'll be focusing on.
@@ -43,8 +43,6 @@ So how do we make Brux run multiple files? Let's make our file structure and fin
 ```
 donut("src/images.nut");
 donut("src/main.nut");
-
-main();
 ```
 
 The list of `donut()` calls will run every source file in your project. Since they're declaring everything as globals, those declarations will remain in Squirrel's memory until Brux itself closes.
@@ -54,18 +52,15 @@ It should be noted that Brux's working directory does not change when you use `d
 In `src/main.nut`, you'll put this code:
 
 ```
-::quit <- false;
+::gameRender <- function () {
+	drawImage(image, 0, 0);
+}
 
-::main <- function(){
-	while(!quit){
-		drawImage(image, 0, 0);
-
-		if(keyPress(k_escape)) quit = true;
-
-		update();
-		wait(10);
-	};
-};
+::gameUpdate <- function () {
+	if (keyPress(k_escape)) {
+		quitGame();
+	}
+}
 ```
 
 Functions and classes don't necessarily need the same declaration method as global variables, but it's a good habit to get into to make it clear they're global.

--- a/rte/src/api/input.cpp
+++ b/rte/src/api/input.cpp
@@ -19,6 +19,8 @@
 
 #include "brux/input.hpp"
 
+bool quitRequested = false;
+
 namespace BruxAPI {
 
 ///////////
@@ -71,7 +73,11 @@ int mouseY() {
 }
 
 bool getQuit() {
-	return gvQuit;
+	return gvQuit || quitRequested;
+}
+
+void quitGame() {
+	quitRequested = true;
 }
 
 int joyCount() {

--- a/rte/src/api/input.hpp
+++ b/rte/src/api/input.hpp
@@ -37,6 +37,7 @@ int mouseRelease(int button); // Doc'd
 int mouseX(); // Doc'd
 int mouseY(); // Doc'd
 bool getQuit(); // Doc'd
+void quitGame(); // Doc'd
 int joyCount(); // Doc'd
 std::string joyName(int i); // Doc'd
 int joyX(int i); // Doc'd

--- a/rte/src/api/main.cpp
+++ b/rte/src/api/main.cpp
@@ -34,6 +34,11 @@ void wait(int seconds) {
 }
 
 void update() {
+	if (!gvUpdateDeprecationWarningShown) {
+		xyPrint(0, "WARNING: update() is deprecated and will be removed in a future release.");
+		gvUpdateDeprecationWarningShown = true;
+	}
+
 	xyUpdate();
 }
 

--- a/rte/src/audio/audio_sdl2.cpp
+++ b/rte/src/audio/audio_sdl2.cpp
@@ -36,7 +36,7 @@ bool didAudioLoadFail = false;
 // NOTE: It doesn't appear to be possible to get the system volume using SDL2.
 
 bool xyIsAudioAvailable() {
-	return isAudioLoaded && !didAudioLoadFail && Mix_MasterVolume(-1) != 0;
+	return isAudioLoaded && !didAudioLoadFail;
 }
 
 // Initialize audio
@@ -56,9 +56,9 @@ void xyInitAudio() {
 		didAudioLoadFail = true;
 		return;
 	}
-	
+
 	isAudioLoaded = true;
-	
+
 	vcSounds.push_back(0);
 	vcMusic.push_back(0);
 }
@@ -85,15 +85,15 @@ void xyAllocateChannels(int channels) {
 
 Uint32 xyLoadSound(const std::string& filename) {
 	// Load the sound file with Mix_LoadWAV()
-	
+
 	Mix_Chunk* newSnd = Mix_LoadWAV(filename.c_str());
-	
+
 	if (newSnd == 0){
 		xyPrint(0, "Failed to load %s! SDL_Mixer Error: %s\n", filename.c_str(), Mix_GetError());
 	}
 
 	// If the array is empty, push the sound onto it and return the first index.
-	
+
 	if (vcSounds.empty()) {
 		vcSounds.push_back(newSnd);
 		return 0;
@@ -112,9 +112,9 @@ Uint32 xyLoadSound(const std::string& filename) {
 		return id;
 	}
 	#endif
-	
+
 	int arraySize = static_cast<int>(vcSounds.size());
-	
+
 	// If the array isn't empty, try to figure out if there are any unloaded sounds that we can replace with a new sound.
 	// Note that i has to start at 1, or it will overwrite the first element that it pushes onto the array, which causes some things (most notably the star powerup in SuperTux Advance) to break.
 	// This is disabled by default, and the fastfill algorithm is used instead.
@@ -122,7 +122,7 @@ Uint32 xyLoadSound(const std::string& filename) {
 	#ifndef USE_FASTFILL
 
 	int i;
-		
+
 	for (i = 1; i < arraySize - 1; i++) {
 		if (vcSounds[i] == NULL) {
 			vcSounds[i] = newSnd;
@@ -134,11 +134,11 @@ Uint32 xyLoadSound(const std::string& filename) {
 	#endif
 
 	// However, if we can't find an unloaded slot to use we'll need to add it as a new array element.
-	
+
 	vcSounds.push_back(newSnd);
-	
+
 	// Yes, I know that this was originally supposed to subtract 1 from the length, and no, this is not a bug. We're using the length value before we added the element, so it ends up being correct.
-	
+
 	return arraySize;
 };
 
@@ -146,17 +146,17 @@ Uint32 xyLoadSound(const std::string& filename) {
 
 Uint32 xyLoadMusic(const std::string& filename) {
 	// Load the music file with Mix_LoadMUS()
-	
+
 	Mix_Music* newMsc = Mix_LoadMUS(filename.c_str());
-	
+
 	// If SDL2 couldn't load it, show an error message with xyPrint()
-	
+
 	if(newMsc == 0) {
 		xyPrint(0, "Failed to load %s! SDL_Mixer Error: %s\n", filename.c_str(), Mix_GetError());
 	}
-	
+
 	// If the array is empty, push the sound onto it and return the first index.
-	
+
 	if (vcMusic.empty()) {
 		vcMusic.push_back(newMsc);
 		return 0;
@@ -181,9 +181,9 @@ Uint32 xyLoadMusic(const std::string& filename) {
 		return id;
 	}
 	#endif
-	
+
 	int arraySize = static_cast<int>(vcMusic.size());
-	
+
 	// If the array isn't empty, try to figure out if there are any unloaded sounds that we can replace with a new sound.
 	// Note that i has to start at 1, or it will overwrite the first element that it pushes onto the array, which causes some things (most notably the star powerup in SuperTux Advance) to break.
 	// This is disabled by default, and the fastfill algorithm is used instead.
@@ -191,7 +191,7 @@ Uint32 xyLoadMusic(const std::string& filename) {
 	#ifndef USE_FASTFILL
 
 	int i;
-		
+
 	for (i = 1; i < arraySize - 1; i++) {
 		if (vcMusic[i] == NULL) {
 			vcMusic[i] = newMsc;
@@ -203,11 +203,11 @@ Uint32 xyLoadMusic(const std::string& filename) {
 	#endif
 
 	// However, if we can't find an unloaded slot to use we'll need to add it as a new array element.
-	
+
 	vcMusic.push_back(newMsc);
-	
+
 	// Yes, I know that this was originally supposed to subtract 1 from the length, and no, this is not a bug. We're using the length value before we added the element, so it ends up being correct.
-	
+
 	return arraySize;
 };
 
@@ -215,27 +215,27 @@ Uint32 xyLoadMusic(const std::string& filename) {
 
 void xyDeleteSound(Uint32 sound) {
 	// If the index is more than or equal to the length of the array (and is thus invalid), don't attempt to unload it.
-	
+
 	if (sound >= vcSounds.size()) {
 		return;
 	}
-	
+
 	// If the index is less than 0, don't attempt to unload it.
 	// The squirrel function does not seem to actually allow negative values to be passed (likely due to how squirrel handles it), but it's still unsafe to assume that it's not negative.
-	
+
 	if (0 > sound) {
 		return;
 	}
-	
+
 	// If the audio data has already been unloaded, don't attempt to unload it.
 	// Note that Kelvin originally wrote this code to check if it's 0 instead of NULL. It does work, but it's a bad practice. Don't do that.
-	
+
 	if (vcSounds[sound] == NULL) {
 		return;
 	}
-	
+
 	// If it is a valid sound, unload it with Mix_FreeChunk and set the pointer in vcSounds to NULL.
-	
+
 	Mix_FreeChunk(vcSounds[sound]);
 	vcSounds[sound] = NULL;
 
@@ -250,27 +250,27 @@ void xyDeleteSound(Uint32 sound) {
 
 void xyDeleteMusic(Uint32 music) {
 	// If the index is more than or equal to the length of the array (and is thus invalid), don't attempt to unload it.
-	
+
 	if (music >= vcMusic.size()) {
 		return;
 	}
-	
+
 	// If the index is less than 0, don't attempt to unload it.
 	// The squirrel function does not seem to actually allow negative values to be passed (likely due to how squirrel handles it), but it's still unsafe to assume that it's not negative.
-	
+
 	if (0 > music) {
 		return;
 	}
-	
+
 	// If the audio data has already been unloaded, don't attempt to unload it.
 	// Note that Kelvin originally wrote this code to check if it's 0 instead of NULL. It does work, but it's a bad practice. Don't do that.
-	
+
 	if (vcMusic[music] == NULL) {
 		return;
 	}
-	
+
 	// If it is a valid song, unload it with Mix_FreeChunk and set the pointer in vcMusic to NULL.
-	
+
 	Mix_FreeMusic(vcMusic[music]);
 	vcMusic[music] = NULL;
 
@@ -285,18 +285,18 @@ void xyDeleteMusic(Uint32 music) {
 
 int xyPlaySound(Uint32 sound, Uint32 loops) {
 	// Play the audio with Mix_PlayChannel()
-	
+
 	int i = Mix_PlayChannel(-1, vcSounds[sound], loops);
-	
+
 	// If it failed, log the error with xyPrint()
-	
+
 	if (i == -1) {
 		xyPrint(0, "Error playing sound! SDL_Mixer Error: %s\n", Mix_GetError());
 		return -1;
 	}
 
 	Mix_Volume(i, gvVolumeSound);
-	
+
 	return i;
 };
 
@@ -309,7 +309,7 @@ int xyPlaySoundChannel(Uint32 sound, Uint32 loops, Uint32 channel) {
 		xyPrint(0, "Error playing sound! SDL_Mixer Error: %s\n", Mix_GetError());
 		return -1;
 	}
-	
+
 	Mix_Volume(i, gvVolumeSound);
 
 	return i;
@@ -319,18 +319,18 @@ int xyPlaySoundChannel(Uint32 sound, Uint32 loops, Uint32 channel) {
 
 int xyPlayMusic(Uint32 music, Uint32 loops) {
 	// Play the audio with Mix_PlayChannel()
-	
+
 	int i = Mix_PlayMusic(vcMusic[music], loops);
-	
+
 	// If it failed, log the error with xyPrint()
-	
+
 	if (i == -1) {
 		xyPrint(0, "Error playing music! SDL_Mixer Error: %s\n", Mix_GetError());
 		return -1;
 	}
 
 	Mix_VolumeMusic(gvVolumeMusic);
-	
+
 	return i;
 };
 
@@ -338,27 +338,27 @@ int xyPlayMusic(Uint32 music, Uint32 loops) {
 
 void xyStopSound(Uint32 sound) {
 	// If the index is more than or equal to the length of the array (and is thus invalid), don't attempt to stop it.
-	
+
 	if (sound >= vcSounds.size()) {
 		return;
 	}
-	
+
 	// If the index is less than 0, don't attempt to stop it.
-	
+
 	if (0 > sound) {
 		return;
 	}
-	
+
 	// If the audio data has already been unloaded, don't attempt to unload it.
-	
+
 	if (vcSounds[sound] == NULL) {
 		return;
 	}
-	
+
 	// Otherwise, stop the audio on all channels using Mix_HaltChannel()
 
 	int i;
-	
+
 	for (i = 0; i < gvMixChannels; i++) {
 		if (Mix_GetChunk(i) == vcSounds[sound]) {
 			Mix_HaltChannel(i);

--- a/rte/src/brux/global.cpp
+++ b/rte/src/brux/global.cpp
@@ -114,6 +114,8 @@ std::string gvAppDir;
 
 std::string gvWorkDir;
 
+// misc
+
 const Uint8 *sdlKeys;
 std::vector<Uint8> keystate(322);
 std::vector<Uint8> keylast(322);
@@ -128,6 +130,7 @@ Uint32 gvMixChannels = 0;
 Uint32 gvVolumeMusic = 128;
 Uint32 gvVolumeSound = 128;
 Uint32 gvDrawTarget = 0;
+bool gvUpdateDeprecationWarningShown = false;
 
 // Gamepad
 // NOTE: I don't know why, I don't want to know why, but *somehow* this entirely breaks if we use the Uint32 type for this

--- a/rte/src/brux/global.hpp
+++ b/rte/src/brux/global.hpp
@@ -81,6 +81,7 @@ extern Uint32 gvMixChannels;
 extern Uint32 gvVolumeMusic;
 extern Uint32 gvVolumeSound;
 extern Uint32 gvDrawTarget;
+extern bool gvUpdateDeprecationWarningShown;
 
 // Gamepad
 

--- a/rte/src/squirrel/wrapper.cpp
+++ b/rte/src/squirrel/wrapper.cpp
@@ -1772,6 +1772,25 @@ static SQInteger getQuit_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger quitGame_wrapper(HSQUIRRELVM vm)
+{
+  (void) vm;
+
+  try {
+    BruxAPI::quitGame();
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'quitGame'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger joyCount_wrapper(HSQUIRRELVM vm)
 {
 
@@ -4599,6 +4618,13 @@ void register_brux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'getQuit'");
+  }
+
+  sq_pushstring(v, "quitGame", -1);
+  sq_newclosure(v, &quitGame_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'quitGame'");
   }
 
   sq_pushstring(v, "joyCount", -1);

--- a/rte/test/test.nut
+++ b/rte/test/test.nut
@@ -232,7 +232,7 @@ if (getAudioDriver() != "None" && isAudioAvailable()) {
 
 ::doTest <- function(name, handler) {
 	print("Test " + str(currentTest) + ": " + name)
-	
+
 	try {
 		handler()
 		print("PASS")
@@ -275,7 +275,11 @@ setFPS(60)
 ::midiFrame <- 0.0
 ::rspeed <- 3.98
 
-while (!getQuit()) {
+::gameUpdate <- function () {
+	if (keyPress(k_enter) || joyAxisPress(0, js_up, js_max / 4)) {
+		quitGame();
+	}
+
 	x = (400 / 2) - ((6 * text.len()) / 2)
 	y = 8 * 2
 
@@ -287,30 +291,28 @@ while (!getQuit()) {
 
 	x += sin(frame / 10.0) * 16.0;
 
+	midiFrame += abs(rspeed) / (8 + abs(rspeed))
+}
+
+::gameRender <- function () {
 	drawSprite(sprOcean, 0, 0, 0)
 	drawSprite(sprMidi, 48 + (midiFrame % 7), midiX, midiY)
 	drawText(font, x, y, text)
 	drawText(font, x2, y2, text2)
-
-	update()
-	frame++;
-	midiFrame += abs(rspeed) / (8 + abs(rspeed))
-
-	if (keyPress(k_enter) || joyAxisPress(0, js_up, js_max / 4)) {
-		break;
-	}
-} 
-
-if (score == total) {
-	print("All tests passed!")
 }
 
-print("Score: " + str(score) + " / " + str(total))
+::gameExit <- function () {
+	if (score == total) {
+		print("All tests passed!")
+	}
 
-if (nonexistantAPIs.len() != 0) {
-	print("Failed to find the following Brux APIs:")
+	print("Score: " + str(score) + " / " + str(total))
 
-	foreach (name in nonexistantAPIs) {
-		print(name)
+	if (nonexistantAPIs.len() != 0) {
+		print("Failed to find the following Brux APIs:")
+
+		foreach (name in nonexistantAPIs) {
+			print(name)
+		}
 	}
 }


### PR DESCRIPTION
Previously, anything using Brux GDK would need to create a main loop which blocks the main thread.

Normally that's perfectly fine, but in a web browser blocking the main thread is something you should NEVER do.

The solution to this problem is to have the engine itself take care of the loop properly, and then the game just defines what should be run on each frame.