### PR TITLE
Fix some bitrot issues

### DIFF
--- a/rte/src/brux/sprite.cpp
+++ b/rte/src/brux/sprite.cpp
@@ -34,7 +34,8 @@ xySprite::xySprite(const std::string& filename, Uint32 width, Uint32 height, Uin
 	numero(0),
 	frames(),
 	tex(xyLoadImage(filename)),
-	name(filename)
+	name(filename),
+	source(filename)
 {
 	//SDL_QueryTexture(vcTextures[tex], format, 0, 0, 0); //// DO NOT USE! ////
 
@@ -88,6 +89,7 @@ xySprite::xySprite(Uint32 texture, Uint32 width, Uint32 height, Uint32 margin, U
 	frames(),
 	tex(),
 	name("texture")
+	source("texture")
 {
 	//SDL_QueryTexture(vcTextures[tex], format, 0, 0, 0); //// DO NOT USE! ////
 

--- a/rte/src/brux/sprite.cpp
+++ b/rte/src/brux/sprite.cpp
@@ -24,7 +24,7 @@
 #include "brux/sprite.hpp"
 #include "brux/maths.hpp"
 
-xySprite::xySprite(const std::string& filename, Uint32 width, Uint32 height, Uint32 margin, Uint32 padding, float pivotX, float pivotY) :
+xySprite::xySprite(const std::string& filename, Uint32 width, Uint32 height, Uint32 margin, Uint32 padding, float pivotX, float pivotY):
 	w(width),
 	h(height),
 	mar(margin),
@@ -88,7 +88,7 @@ xySprite::xySprite(Uint32 texture, Uint32 width, Uint32 height, Uint32 margin, U
 	numero(0),
 	frames(),
 	tex(),
-	name("texture")
+	name("texture"),
 	source("texture")
 {
 	//SDL_QueryTexture(vcTextures[tex], format, 0, 0, 0); //// DO NOT USE! ////

--- a/rte/src/brux/sprite.hpp
+++ b/rte/src/brux/sprite.hpp
@@ -30,6 +30,7 @@ private:
 	Uint32 *format;
 public:
 	std::string name;
+	std::string source;
 	xySprite(const std::string& filename, Uint32 width, Uint32 height, Uint32 margin, Uint32 padding, float pivotX, float pivotY);
 	xySprite(Uint32 texture, Uint32 width, Uint32 height, Uint32 margin, Uint32 padding, float pivotX, float pivotY);
 	~xySprite();

--- a/rte/test/test.nut
+++ b/rte/test/test.nut
@@ -232,7 +232,7 @@ if (getAudioDriver() != "None" && isAudioAvailable()) {
 
 ::doTest <- function(name, handler) {
 	print("Test " + str(currentTest) + ": " + name)
-
+	
 	try {
 		handler()
 		print("PASS")
@@ -275,11 +275,7 @@ setFPS(60)
 ::midiFrame <- 0.0
 ::rspeed <- 3.98
 
-::gameUpdate <- function () {
-	if (keyPress(k_enter) || joyAxisPress(0, js_up, js_max / 4)) {
-		quitGame();
-	}
-
+while (!getQuit()) {
 	x = (400 / 2) - ((6 * text.len()) / 2)
 	y = 8 * 2
 
@@ -291,28 +287,30 @@ setFPS(60)
 
 	x += sin(frame / 10.0) * 16.0;
 
-	midiFrame += abs(rspeed) / (8 + abs(rspeed))
-}
-
-::gameRender <- function () {
 	drawSprite(sprOcean, 0, 0, 0)
 	drawSprite(sprMidi, 48 + (midiFrame % 7), midiX, midiY)
 	drawText(font, x, y, text)
 	drawText(font, x2, y2, text2)
+
+	update()
+	frame++;
+	midiFrame += abs(rspeed) / (8 + abs(rspeed))
+
+	if (keyPress(k_enter) || joyAxisPress(0, js_up, js_max / 4)) {
+		break;
+	}
+} 
+
+if (score == total) {
+	print("All tests passed!")
 }
 
-::gameExit <- function () {
-	if (score == total) {
-		print("All tests passed!")
-	}
+print("Score: " + str(score) + " / " + str(total))
 
-	print("Score: " + str(score) + " / " + str(total))
+if (nonexistantAPIs.len() != 0) {
+	print("Failed to find the following Brux APIs:")
 
-	if (nonexistantAPIs.len() != 0) {
-		print("Failed to find the following Brux APIs:")
-
-		foreach (name in nonexistantAPIs) {
-			print(name)
-		}
+	foreach (name in nonexistantAPIs) {
+		print(name)
 	}
 }


### PR DESCRIPTION
This commit solves 2 bitrot issues:
    
1. Some code was added to rte/src/brux/sprite.cpp in commit 2682b8109f2faefad69441171489c53432eee1cf which does not actually compile.
2. rte/test/test.nut was updated in commit 438d0342871296f2f9828d63fe4f4e90da4f1a9f to use the function-based loop system, but after that change was reverted the test code was not.