### PR TITLE
Fix paths provided without `./` (while also containing a subdir) resulting in an immediate exit (unmessed up PR edition)

### DIFF
--- a/rte/src/brux/main.cpp
+++ b/rte/src/brux/main.cpp
@@ -55,18 +55,14 @@ int main(int argc, char* argv[]) {
 		FS.chdir('/bin');
 	);
 #endif
-
 	// Initialize the file system (PhysFS)
-	
 	xyFSInit();
 	
 	// Mount the current working directory.
-		 
 	xyFSMount(xyGetDir(), "/", true);
 
 	// Set the current write directory to a default for Brux.
 	// Can be changed later by the game.
-		
 	xySetWriteDir(xyGetPrefDir("brux", "brux"));
 
 	// Process arguments
@@ -99,16 +95,19 @@ int main(int argc, char* argv[]) {
 					size_t found = xygapp.find_last_of("/\\");
 					
 					//If local file provided without ./ before it, use local directory
-					if(found != -1)
+					if (found != -1) {
 						gvWorkDir = xygapp.substr(0, found);
-					else
+
+						xygapp = xygapp.substr(found+1);
+						
+						if (chdir(gvWorkDir.c_str()) != 0) {
+							xyPrint("Error initializing Brux: Cannot change to input file working directory: %d", errno);
+							xyPrint(gvWorkDir.c_str());
+							xyEnd();
+							return 1;
+						}
+					} else {
 						gvWorkDir = ".";
-					
-					if (chdir(gvWorkDir.c_str()) != 0) {
-						xyPrint("Error initializing Brux: Cannot change to input file working directory: %d", errno);
-						xyPrint(gvWorkDir.c_str());
-						xyEnd();
-						return 1;
 					}
 					
 					const std::string curdir = xyGetDir();
@@ -127,7 +126,6 @@ int main(int argc, char* argv[]) {
 		shouldLoad = true;
 	} else {
 		// If the filename is blank, attempt to load game.brx or test.nut as a fallback.
-		
 		if (xyFileExists("game.brx")) {
 			xygapp = "game.brx";
 			shouldLoad = true;

--- a/rte/src/brux/main.cpp
+++ b/rte/src/brux/main.cpp
@@ -98,6 +98,7 @@ int main(int argc, char* argv[]) {
 					if (found != -1) {
 						gvWorkDir = xygapp.substr(0, found);
 
+						// Remove dir from xygapp so we can actually find the file
 						xygapp = xygapp.substr(found+1);
 						
 						if (chdir(gvWorkDir.c_str()) != 0) {


### PR DESCRIPTION
The issue was caused by not actually updating xygapp to reflect the chdir done immediately afterwards (e.g. `build/test.nut` does not exist in the `build` directory.

I probably didn't need to make a new PR (could have just fixed the previous one) but heyho.