### PR TITLE
add cmakelists file to root because its standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(rte)


### PR DESCRIPTION
to make building the project easier not just for other users but for even ci tools adding a cmake file to the root simplifies a lot of tools.